### PR TITLE
Updating styles to correctly position user's role title in Safari

### DIFF
--- a/app/scss/epochtalk/epochtalk.scss
+++ b/app/scss/epochtalk/epochtalk.scss
@@ -787,6 +787,7 @@ pagination {
     color: #fff;
     font-size: .8125em;
     font-weight: 600;
+    left: 0;
     padding: 3px;
     position: absolute;
     text-align: center;


### PR DESCRIPTION
Role position left was not set - so Safari was not positioning properly
Fixes #50