### PR TITLE
Added separate state for viewing only user's posts

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -85,6 +85,55 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
       }
     });
 
+    $stateProvider.state('users-posts', {
+      url: '/profiles/{username}/posts?limit&page&field&desc',
+      parent: 'public-layout',
+      reloadOnSearch: false,
+      views: {
+        'content': {
+          controller: 'ProfilePostsCtrl',
+          controllerAs: 'ProfilePostsCtrl',
+          template: fs.readFileSync(__dirname + '/user/posts.html')
+        }
+      },
+      resolve: {
+        $title: ['$stateParams', function($stateParams) {
+          return 'Posts by ' + $stateParams.username;
+        }],
+        user: [ 'User', '$stateParams', function(User, $stateParams) {
+          return User.get({ id: $stateParams.username }).$promise
+          .then(function(user) { return user; });
+        }],
+        limit: ['$stateParams', function($stateParams) {
+          return $stateParams.limit || 10;
+        }],
+        page: ['$stateParams', function($stateParams) {
+          return Number($stateParams.page) || 1;
+        }],
+        field: ['$stateParams', function($stateParams) {
+          return $stateParams.field;
+        }],
+        desc: ['$stateParams', function($stateParams) {
+          return $stateParams.desc || true;
+        }],
+        usersPostsCount: ['Posts', '$stateParams', function(Posts, $stateParams) {
+          return Posts.pageByUserCount({ username: $stateParams.username }).$promise
+          .then(function(usersCount) { return usersCount.count; });
+        }],
+        usersPosts: ['Posts', '$stateParams', function(Posts, $stateParams) {
+          var params = {
+            username: $stateParams.username,
+            field: $stateParams.field,
+            desc: $stateParams.desc || true,
+            limit: Number($stateParams.limit) || 10,
+            page: Number($stateParams.page) || 1
+          };
+          return Posts.pageByUser(params).$promise
+          .then(function(usersPosts) { return usersPosts; });
+        }]
+      }
+    });
+
     $stateProvider.state('confirm', {
       url: '/confirm/{username}/{token}',
       parent: 'public-layout',
@@ -578,6 +627,9 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
         }
       },
       resolve: {
+        $title: ['$stateParams', function($stateParams) {
+          return $stateParams.username;
+        }],
         user: [ 'User', '$stateParams', function(User, $stateParams) {
           return User.get({ id: $stateParams.username }).$promise
           .then(function(user) { return user; });

--- a/app/services/breadcrumbs.js
+++ b/app/services/breadcrumbs.js
@@ -47,9 +47,10 @@ function ($stateParams, $location, Breadcrumbs) {
         threadId: 'thread',
         postId:   'post'
       };
-      var routeParamKeys = Object.keys(routeParams);
+      var routeParamKeys = _.without(Object.keys(routeParams), '#'); // remove anchor hash from params
       var keys = Object.keys(keyToType);
       var matches = _.intersection(routeParamKeys, keys);
+
       // matches, route is dynamic
       if (!_.isEmpty(matches)) {
         var idKey = routeParamKeys.reverse()[0];

--- a/app/user/posts.controller.js
+++ b/app/user/posts.controller.js
@@ -1,5 +1,5 @@
-module.exports = ['user', 'usersPosts', 'usersPostsCount', 'limit', 'page', 'field', 'desc', 'Posts', '$location', '$scope', '$rootScope', '$state',
-  function(user, usersPosts, usersPostsCount, limit, page, field, desc, Posts, $location, $scope, $rootScope, $state) {
+module.exports = ['user', 'usersPosts', 'usersPostsCount', 'limit', 'page', 'field', 'desc', 'Posts', '$location', '$scope', '$rootScope', '$state', '$anchorScroll',
+  function(user, usersPosts, usersPostsCount, limit, page, field, desc, Posts, $location, $scope, $rootScope, $state, $anchorScroll) {
     var ctrl = this;
     this.user = user;
     this.pageCount = Math.ceil(usersPostsCount / limit);
@@ -9,6 +9,8 @@ module.exports = ['user', 'usersPosts', 'usersPostsCount', 'limit', 'page', 'fie
     this.field = field;
     this.desc = desc;
     this.usersPosts = usersPosts;
+
+    if ($state.current.name === 'users-posts') { $anchorScroll(); }
 
     this.setSortField = function(sortField) {
       // Sort Field hasn't changed just toggle desc

--- a/app/user/profile.controller.js
+++ b/app/user/profile.controller.js
@@ -10,6 +10,7 @@ module.exports = ['user', 'User', 'Session', 'Alert', '$timeout', '$filter', '$s
     this.displayAvatar = angular.copy(this.user.avatar || 'http://fakeimg.pl/400x400/ccc/444/?text=' + user.username);
     // This isn't the profile users true local time, just a placeholder
     this.userLocalTime = $filter('date')(Date.now(), 'h:mm a (Z)');
+    this.displayPostsUrl = false;
 
     var calcAge = function(dob) {
       if (!dob) { return '';}
@@ -134,6 +135,9 @@ module.exports = ['user', 'User', 'Session', 'Alert', '$timeout', '$filter', '$s
       // Load posts state with proper state params
       var params = $location.search();
       $state.go('profile.posts', params, { location: false, reload: 'profile.posts' });
+    }
+    else {
+      this.displayPostsUrl = true;
     }
   }
 ];

--- a/app/user/profile.html
+++ b/app/user/profile.html
@@ -22,6 +22,7 @@
     <div><span ng-bind="::ProfileCtrl.user.name"></span></div>
     <div><span ng-bind="::ProfileCtrl.user.position"></span></div>
     <div><span ng-bind="::ProfileCtrl.user.status"></span></div>
+    <div ng-if="ProfileCtrl.displayPostsUrl"><a ui-sref="users-posts({ username: ProfileCtrl.user.username })" ui-sref-opts="{ reload: true }">View Posts</a></div>
     <hr ng-if="ProfileCtrl.displayEmail || ProfileCtrl.user.btcAddress || ProfileCtrl.user.website">
     <div><span ng-bind="::ProfileCtrl.displayEmail"></span></div>
     <div><span ng-bind="::ProfileCtrl.user.btcAddress"></span></div>


### PR DESCRIPTION
* Users posts can now be viewed by going to /profile/{username}/posts

* There is now a link to view a users posts in the profile preview on
  the admin users moderation page.

* Removed unused state parameter from resolve

Test procedure:

* Visit /profiles/{username}/posts, you should be able to page through a users posts in this view.

* Visit /admin/moderation/users, select a user report. In the user's profile preview, below the user info should be a link "View Posts". This should link to an independent view for paging through the user's posts