### PR TITLE
Hooked up admin general settings to website

### DIFF
--- a/app/admin/settings/general.html
+++ b/app/admin/settings/general.html
@@ -11,17 +11,11 @@
     <label for="website-keywords">Website Keywords</label>
     <input type="text" id="website-keywords" ng-model="AdminSettingsCtrl.settings.website.keywords" placeholder="Example: epochtalk, forum, open source, support" />
     <label for="website-logo-upload-btn">Website Logo</label>
-    <div class="nested-input-container">
-      <a ng-href="" class="nested-btn upload-btn">Upload</a>
-      <input type="file" id="website-logo-upload-btn" class="file-upload" />
-      <input class="nested-input upload-btn" type="text" id="website-logo" ng-model="AdminSettingsCtrl.settings.website.logo" placeholder="default_logo.png" />
-    </div>
+    <image-uploader class="editor-image-uploader" model="AdminSettingsCtrl.settings.website.logo" purpose="logo"></image-uploader>
+    <input type="text" id="website-logo" ng-model="AdminSettingsCtrl.settings.website.logo" placeholder="default_logo.png" />
     <label for="website-favicon-upload-btn">Website Favicon</label>
-    <div class="nested-input-container">
-      <a ng-href="" class="nested-btn upload-btn">Upload</a>
-      <input type="file" id="website-favicon-upload-btn" class="file-upload" />
-      <input class="nested-input" type="text" id="website-favicon" ng-model="AdminSettingsCtrl.settings.website.favicon" placeholder="favicon.ico" />
-    </div>
+    <image-uploader class="editor-image-uploader" model="AdminSettingsCtrl.settings.website.favicon" purpose="favicon"></image-uploader>
+    <input type="text" id="website-favicon" ng-model="AdminSettingsCtrl.settings.website.favicon" placeholder="favicon.ico" />
 
     <!-- Database Tasks -->
     <h5 class="thin-dotted-underline section-header-top-spacing">Database Tasks</h5>
@@ -30,21 +24,21 @@
       <label class="desc-label" for="database-backup">Creates and downloads a backup of all forum data</label>
     </div>
     <div class="small-12 large-3 columns column-padding-fix">
-      <a id="database-backup" class="admin-btn">Backup</a>
+      <a id="database-backup" class="admin-btn" style="background-color: #CCC;">Backup</a>
     </div>
     <div class="small-12 large-9 columns column-padding-fix column-spacing-fix column-padding-top">
       <label for="database-restore">Restore Database</label>
       <label class="desc-label" for="database-restore">Allows restoration of forum data from a backup file</label>
     </div>
     <div class="small-12 large-3 columns column-padding-fix column-btn-padding-top">
-      <a id="database-restore" class="admin-btn">Restore</a>
+      <a id="database-restore" class="admin-btn" style="background-color: #CCC;">Restore</a>
     </div>
     <div class="small-12 large-9 columns column-padding-fix column-spacing-fix column-padding-top">
       <label for="database-migrate">Migrate Database</label>
       <label class="desc-label" for="database-migrate">Launches wizard to migrate data from other forums</label>
     </div>
     <div class="small-12 large-3 columns column-padding-fix column-btn-padding-top">
-      <a id="database-migrate" class="admin-btn">Migrate</a>
+      <a id="database-migrate" class="admin-btn" style="background-color: #CCC;">Migrate</a>
     </div>
   </div>
 

--- a/app/app.js
+++ b/app/app.js
@@ -67,7 +67,12 @@ app.directive('autocompleteUsername',   require('./components/autocomplete_usern
 
 // Set Angular Configs
 app.config(require('./config'))
-.run(['$rootScope', '$state', '$timeout', 'Auth', 'BreadcrumbSvc', function($rootScope, $state, $timeout, Auth, BreadcrumbSvc) {
+.run(['$rootScope', '$state', '$timeout', 'Auth', 'BreadcrumbSvc', 'Settings', function($rootScope, $state, $timeout, Auth, BreadcrumbSvc, Settings) {
+
+  // Fetch website configs (title, keywords, desc...)
+  Settings.webConfigs().$promise
+  .then(function(configs) { $rootScope.$webConfigs = configs; })
+  .catch(function() { console.log('Error fetching website configs'); });
 
   // Load foundation on view change
   $rootScope.$on('$viewContentLoaded', function() {

--- a/app/components/image_uploader/image_uploader.directive.js
+++ b/app/components/image_uploader/image_uploader.directive.js
@@ -10,7 +10,7 @@ module.exports = ['$timeout', 'S3ImageUpload', 'Alert',
       onDone: '&'
     },
     template: fs.readFileSync(__dirname + '/image_uploader.html'),
-    link: function($scope, $element, $attrs) {
+    link: function($scope, $element) {
       // directive initialization
       $scope.images = [];
       $scope.imagesUploading = false;
@@ -27,11 +27,14 @@ module.exports = ['$timeout', 'S3ImageUpload', 'Alert',
       if ($scope.purpose === 'editor') {
         $(inputElement).attr('multiple', '');
       }
+      else if ($scope.purpose === 'favicon') {
+        $(inputElement).attr('accept', 'image/x-icon');
+      }
 
       function upload(images) {
         $scope.imagesUploading = true;
         $scope.imagesProgress = 0;
-        if ($scope.purpose === 'avatar') { $scope.images = []; }
+        if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { $scope.images = []; }
         // upload each image
         images.forEach(function(image) {
           var imageProgress = {
@@ -54,7 +57,7 @@ module.exports = ['$timeout', 'S3ImageUpload', 'Alert',
               imageProgress.status = 'Uploading';
               updateImagesUploading();
             })
-            .error(function(data) {
+            .error(function() {
               imageProgress.progress = '--';
               imageProgress.status = 'Failed';
               updateImagesUploading();
@@ -68,12 +71,12 @@ module.exports = ['$timeout', 'S3ImageUpload', 'Alert',
               imageProgress.url = url;
               updateImagesUploading();
               if ($scope.onDone) { $scope.onDone({data: url}); }
-              if ($scope.purpose === 'avatar') { $scope.model = url; }
+              if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { $scope.model = url; }
             });
           })
           .catch(function() {
             imageProgress.progress = '--';
-            imageProgress.status = "Failed";
+            imageProgress.status = 'Failed';
             updateImagesUploading();
             var message = 'Image upload failed for: ' + imageProgress.name + '.';
             message += 'Please ensure images are within size limits.';
@@ -121,9 +124,9 @@ module.exports = ['$timeout', 'S3ImageUpload', 'Alert',
         e.stopPropagation();
         e.preventDefault();
       };
-      $parent.on("dragenter", cancelEvent);
-      $parent.on("dragover", cancelEvent);
-      $parent.on("drop", function(e) {
+      $parent.on('dragenter', cancelEvent);
+      $parent.on('dragover', cancelEvent);
+      $parent.on('drop', function(e) {
         cancelEvent(e);
         var dt = e.dataTransfer;
         var fileList = dt.files;
@@ -133,7 +136,7 @@ module.exports = ['$timeout', 'S3ImageUpload', 'Alert',
           if (!file.type.match(/image.*/)) { continue; }
           images.push(file);
         }
-        if ($scope.purpose === 'avatar') { images = [images[0]]; }
+        if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { images = [images[0]]; }
         upload(images);
       });
 

--- a/app/layout/header.admin.html
+++ b/app/layout/header.admin.html
@@ -3,7 +3,10 @@
   <!-- For mobile -->
   <ul class="title-area">
     <li class="logo">
-      <a ng-href="/admin"><i class="fa fa-list-ul fa-2x"></i></a>
+      <a ng-href="/admin">
+        <img ng-if="$webConfigs.logo" ng-src="{{ $webConfigs.logo }}" width="35" height="35" />
+        <div ng-hide="$webConfigs.logo" ng-bind="$webConfigs.title" class="admin-title"></div>
+      </a>
     </li>
 
     <li class="toggle-topbar menu-icon">
@@ -17,7 +20,8 @@
       <li ng-if="HeaderCtrl.currentUser.isAdmin"><a ng-class="HeaderCtrl.checkAdminRoute('settings') ? 'top-bar-btn-selected' : 'top-bar-btn'" ui-sref="admin-settings.general" ui-sref-opts="{ reload: true }"><i class="fa fa-cogs"></i>&nbsp;&nbsp;&nbsp;Settings</a></li>
       <li ng-if="HeaderCtrl.currentUser.isAdmin"><a ng-class="HeaderCtrl.checkAdminRoute('management') ? 'top-bar-btn-selected' : 'top-bar-btn'" ui-sref="admin-management.boards" ui-sref-opts="{ reload: true }"><i class="fa fa-briefcase"></i>&nbsp;&nbsp;&nbsp;Management</a></li>
       <li ng-if="HeaderCtrl.currentUser.isAdmin || HeaderCtrl.currentUser.isMod"><a ng-class="HeaderCtrl.checkAdminRoute('moderation') ? 'top-bar-btn-selected' : 'top-bar-btn'" ui-sref="admin-moderation.users({ filter: 'Pending' })" ui-sref-opts="{ reload: true }"><i class="fa fa-users"></i>&nbsp;&nbsp;&nbsp;Moderation</a></li>
-      <li ng-if="HeaderCtrl.currentUser.isAdmin"><a ng-class="HeaderCtrl.checkAdminRoute('analytics') ? 'top-bar-btn-selected' : 'top-bar-btn'" ui-sref="admin-analytics" ui-sref-opts="{ reload: true }"><i class="fa fa-line-chart"></i>&nbsp;&nbsp;&nbsp;Analytics</a></li>
+      <li ng-if="HeaderCtrl.currentUser.isAdmin"><a ng-class="HeaderCtrl.checkAdminRoute('analytics') ? 'top-bar-btn-selected' : 'top-bar-btn'" href="#" style="color: #888;"><i class="fa fa-line-chart"></i>&nbsp;&nbsp;&nbsp;Analytics</a></li>
+      <!--<li ng-if="HeaderCtrl.currentUser.isAdmin"><a ng-class="HeaderCtrl.checkAdminRoute('analytics') ? 'top-bar-btn-selected' : 'top-bar-btn'" ui-sref="admin-analytics" ui-sref-opts="{ reload: true }"><i class="fa fa-line-chart"></i>&nbsp;&nbsp;&nbsp;Analytics</a></li>-->
     </ul>
     <!-- Right Nav Section -->
     <ul class="right login-container">

--- a/app/layout/header.html
+++ b/app/layout/header.html
@@ -6,7 +6,10 @@
         <!-- For mobile -->
         <ul class="title-area">
           <li class="name">
-            <h1><a ng-href="/">Epochtalk</a></h1>
+            <h1>
+              <a ng-href="/" ng-if="$webConfigs.logo"><img ng-src="{{$webConfigs.logo}}" class="logo" /></a>
+              <a ng-href="/" ng-bind="$webConfigs.title">Epochtalk</a>
+            </h1>
           </li>
           <li class="toggle-topbar menu-icon">
             <a ng-href="#"><span>Menu</span></a>

--- a/app/resources/index.js
+++ b/app/resources/index.js
@@ -6,4 +6,5 @@ angular.module('ept')
   .factory('Threads', require('./threads.js'))
   .factory('Posts', require('./posts.js'))
   .factory('Reports', require('./reports.js'))
+  .factory('Settings', require('./settings.js'))
   .factory('User', require('./user.js'));

--- a/app/resources/settings.js
+++ b/app/resources/settings.js
@@ -1,0 +1,13 @@
+'use strict';
+/* jslint node: true */
+
+module.exports = ['$resource',
+  function($resource) {
+    return $resource('/api/settings', {}, {
+      webConfigs: {
+        url: '/api/settings/web',
+        method: 'GET'
+      }
+    });
+  }
+];

--- a/app/scss/epochtalk/epochtalk.scss
+++ b/app/scss/epochtalk/epochtalk.scss
@@ -145,6 +145,13 @@ label > input[type="checkbox"] { margin-right: .25rem; }
 /* Magellan */
 .magellan-override { padding: 0px; background: transparent; }
 .top-bar .name h1 { font-family: 'Inconsolata'; font-size: 20px; }
+.top-bar .name h1 a { display: inline-block; }
+.top-bar .name h1 .logo {
+  padding-right: 10px;
+  width: 35px;
+  height: 25px;
+  margin-bottom: 4px;
+}
 
 // Page Controls ----------------------------- //
 .page-controls {
@@ -256,6 +263,7 @@ input.icon-padding { padding-right: 40px; }
 
     .name a { color: inherit; padding: 0; }
     .logo a { color: inherit; padding-top: 20px; }
+    .logo a .admin-title { padding-top: 3px; }
 
     .title-area { background-color: inherit; }
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,10 @@
   <base href="/">
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title ng-bind="'Epochtalk - ' + ($title || 'Home')">Epochtalk</title>
+  <title ng-bind="$webConfigs.title + ' - ' + ($title || 'Home')">Epochtalk</title>
+  <meta name="description" content="{{$webConfigs.description}}" />
+  <meta name="keywords" content="{{$webConfigs.keywords}}">
+  <link rel="shortcut icon" type="image/x-icon" href="{{$webConfigs.favicon}}">
   <link rel="stylesheet" href="/static/css/app.css"/>
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
   <style>

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,12 +12,13 @@ var posts = require(path.normalize(__dirname + '/posts'));
 var users = require(path.normalize(__dirname + '/users'));
 var auth = require(path.normalize(__dirname + '/auth'));
 var reports = require(path.normalize(__dirname + '/reports'));
+var settings = require(path.normalize(__dirname + '/settings'));
 var adminSettings = require(path.normalize(__dirname + '/admin/settings'));
 var adminUsers = require(path.normalize(__dirname + '/admin/users'));
 var adminReports = require(path.normalize(__dirname + '/admin/reports'));
 
 function buildEndpoints() {
-  return [].concat(breadcrumbs, categories, boards, threads, posts, users, auth, reports);
+  return [].concat(breadcrumbs, categories, boards, threads, posts, users, auth, reports, settings);
 }
 
 function buildAdminEndpoints() {

--- a/server/routes/settings/config.js
+++ b/server/routes/settings/config.js
@@ -1,0 +1,9 @@
+var path = require('path');
+var config = require(path.normalize(__dirname + '/../../../config'));
+
+exports.webConfigs = {
+  auth: { mode: 'try', strategy: 'jwt' },
+  handler: function(request, reply) {
+    reply(config.website);
+  }
+};

--- a/server/routes/settings/index.js
+++ b/server/routes/settings/index.js
@@ -1,0 +1,6 @@
+var path = require('path');
+var settings = require(path.normalize(__dirname + '/config'));
+
+module.exports = [
+  { method: 'GET', path: '/settings/web', config: settings.webConfigs },
+];


### PR DESCRIPTION
* Website title, description, keywords, logo and fav icon are now
  functional. Settings will update upon reload of the web app to avoid
  constantly polling on every state change. This can easily be changed
  if needed, but these events should be a rare enough occasion that it
  doesn't warrant being updated on every state change.

* Added settings api endpoint. Currently there is only one route which
  brings back the website configs.

* Added settings resource for grabbing settings on the client side.

* Modified image uploader directive to accept two new purposes: logo
  and favicon. Logo behaves identically like the "avatar" purpose.
  "favicon" only allows the user to upload the .ico filetype.

* Greyed out Analytics link in the admin header.

* Greyed out the database option in the general settings admin page.

Testing Procedure:

* Visit the admin general settings page and try changing all of the settings under "Web Configurations"

* Reload the web app and confirm that the settings have updated on the client side. 

  * Website title is visible on home page and title bar. 

  * Description is visible in the html meta tags

  * Keywords are visible in the html meta tags

  * Favicon should show up in the url bar

  * Logo should show up next to the site title on the home page

  * Analytics and database functions in admin panel should be greyed out
