### PR TITLE
Consolidated user roles into constants. Misc Fixes

### DIFF
--- a/app/admin/management/administrators.controller.js
+++ b/app/admin/management/administrators.controller.js
@@ -1,4 +1,4 @@
-module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminUsers', 'admins', 'adminsCount', 'page', 'limit', 'field', 'desc', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminUsers, admins, adminsCount, page, limit, field, desc) {
+module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminUsers', 'admins', 'adminsCount', 'page', 'limit', 'field', 'desc', 'USER_ROLES', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminUsers, admins, adminsCount, page, limit, field, desc, USER_ROLES) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'administrators';
@@ -29,6 +29,11 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     ctrl.selectedUser = null;
     ctrl.selectedRole = null;
     ctrl.showConfirmAddModal = false;
+
+    $timeout(function() { // wait for modal to close
+      ctrl.confirmAddBtnLabel = 'Confirm';
+      ctrl.roleAddSubmitted = false;
+    }, 1000);
   };
 
   this.addAdministrator = function() {
@@ -36,14 +41,14 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     ctrl.roleAddSubmitted = true;
     var hasAdminRole = false;
     ctrl.selectedUser.roles.forEach(function(role) {
-      if (role === 'Administrator' || role.name === 'Super Administrator') { hasAdminRole = true; }
+      if (role.name === USER_ROLES.admin || role.name === USER_ROLES.superAdmin) { hasAdminRole = true; }
     });
 
     if (hasAdminRole) { ctrl.closeConfirmAdd(); }
     else {
-      var roles = [ 'Administrator' ]; // default to admin role
-      if (ctrl.selectedRole === 'Super Administrator') { // Append super admin role if selected
-        roles.push('Super Administrator');
+      var roles = [ USER_ROLES.admin ]; // default to admin role
+      if (ctrl.selectedRole === USER_ROLES.superAdmin) { // Append super admin role if selected
+        roles.push(USER_ROLES.superAdmin);
       }
       var params = {
         user_id: ctrl.selectedUser.id,
@@ -53,11 +58,6 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       .then(function() {
         ctrl.closeConfirmAdd();
         ctrl.pullPage();
-
-        $timeout(function() { // wait for modal to close
-          ctrl.confirmAddBtnLabel = 'Confirm';
-          ctrl.roleAddSubmitted = false;
-        }, 500);
       });
     }
   };
@@ -75,6 +75,10 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   this.closeConfirmRemove = function() {
     ctrl.selectedUser = null;
 
+    $timeout(function() { // wait for modal to close
+      ctrl.confirmRemoveBtnLabel = 'Confirm';
+      ctrl.roleRemoveSubmitted = false;
+    }, 1000);
     // fix for modal not opening after closing
     $timeout(function() { ctrl.showConfirmRemoveModal = false; });
   };
@@ -90,10 +94,6 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     .then(function() {
       ctrl.pullPage();
       ctrl.closeConfirmRemove();
-      $timeout(function() { // wait for modal to close
-        ctrl.confirmRemoveBtnLabel = 'Confirm';
-        ctrl.roleRemoveSubmitted = false;
-      }, 500);
     });
   };
 
@@ -101,7 +101,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   this.toggleSuperAdmin = function(userId, setSuperAdmin) {
     var params = {
       user_id: userId,
-      roles: ['Super Administrator']
+      roles: [USER_ROLES.superAdmin]
     };
     var promise;
     if (setSuperAdmin) { promise = AdminUsers.addRoles(params).$promise; }
@@ -145,7 +145,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   };
 
   this.isSuperAdmin = function(roles) {
-    return roles.indexOf('Super Administrator') > -1;
+    return roles.indexOf(USER_ROLES.superAdmin) > -1;
   };
 
   $timeout($anchorScroll);

--- a/app/admin/management/moderators.controller.js
+++ b/app/admin/management/moderators.controller.js
@@ -1,4 +1,4 @@
-module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminUsers', 'moderators', 'moderatorsCount', 'page', 'limit', 'field', 'desc', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminUsers, moderators, moderatorsCount, page, limit, field, desc) {
+module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminUsers', 'moderators', 'moderatorsCount', 'page', 'limit', 'field', 'desc', 'USER_ROLES', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminUsers, moderators, moderatorsCount, page, limit, field, desc, USER_ROLES) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'moderators';
@@ -28,6 +28,11 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     ctrl.selectedUser = null;
     ctrl.selectedRole = null;
     ctrl.showConfirmAddModal = false;
+
+    $timeout(function() { // wait for modal to close
+      ctrl.confirmAddBtnLabel = 'Confirm';
+      ctrl.roleAddSubmitted = false;
+    }, 1000);
   };
 
   this.addModerator = function() {
@@ -35,14 +40,14 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     ctrl.roleAddSubmitted = true;
     var hasModRole = false;
     ctrl.selectedUser.roles.forEach(function(role) {
-      if (role === 'Moderator' || role.name === 'Global Moderator') { hasModRole = true; }
+      if (role.name === USER_ROLES.mod || role.name === USER_ROLES.globalMod) { hasModRole = true; }
     });
 
     if (hasModRole) { ctrl.closeConfirmAdd(); }
     else {
-      var roles = [ 'Moderator' ]; // default to mod role
-      if (ctrl.selectedRole === 'Global Moderator') { // Append global mod role if selected
-        roles.push('Global Moderator');
+      var roles = [ USER_ROLES.mod ]; // default to mod role
+      if (ctrl.selectedRole === USER_ROLES.globalMod) { // Append global mod role if selected
+        roles.push(USER_ROLES.globalMod);
       }
       var params = {
         user_id: ctrl.selectedUser.id,
@@ -52,11 +57,6 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       .then(function() {
         ctrl.closeConfirmAdd();
         ctrl.pullPage();
-
-        $timeout(function() { // wait for modal to close
-          ctrl.confirmAddBtnLabel = 'Confirm';
-          ctrl.roleAddSubmitted = false;
-        }, 500);
       });
     }
   };
@@ -74,6 +74,10 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   this.closeConfirmRemove = function() {
     ctrl.selectedUser = null;
 
+    $timeout(function() { // wait for modal to close
+      ctrl.confirmRemoveBtnLabel = 'Confirm';
+      ctrl.roleRemoveSubmitted = false;
+    }, 1000);
     // fix for modal not opening after closing
     $timeout(function() { ctrl.showConfirmRemoveModal = false; });
   };
@@ -89,10 +93,6 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     .then(function() {
       ctrl.pullPage();
       ctrl.closeConfirmRemove();
-      $timeout(function() { // wait for modal to close
-        ctrl.confirmRemoveBtnLabel = 'Confirm';
-        ctrl.roleRemoveSubmitted = false;
-      }, 500);
     });
   };
 
@@ -100,7 +100,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   this.toggleGlobalMod = function(userId, setGlobalMod) {
     var params = {
       user_id: userId,
-      roles: ['Global Moderator']
+      roles: [ USER_ROLES.globalMod ]
     };
     var promise;
     if (setGlobalMod) { promise = AdminUsers.addRoles(params).$promise; }
@@ -144,7 +144,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   };
 
   this.isGlobalMod = function(roles) {
-    return roles.indexOf('Global Moderator') > -1;
+    return roles.indexOf(USER_ROLES.globalMod) > -1;
   };
 
   $timeout($anchorScroll);

--- a/app/app.js
+++ b/app/app.js
@@ -67,7 +67,17 @@ app.directive('autocompleteUsername',   require('./components/autocomplete_usern
 
 // Set Angular Configs
 app.config(require('./config'))
-.run(['$rootScope', '$state', '$timeout', 'Auth', 'BreadcrumbSvc', 'Settings', function($rootScope, $state, $timeout, Auth, BreadcrumbSvc, Settings) {
+.constant('USER_ROLES', {
+  user: 'User',
+  mod: 'Moderator',
+  globalMod: 'Global Moderator',
+  admin: 'Administrator',
+  superAdmin: 'Super Administrator'
+})
+.run(['$rootScope', '$state', '$timeout', 'Auth', 'BreadcrumbSvc', 'Settings', 'USER_ROLES', function($rootScope, $state, $timeout, Auth, BreadcrumbSvc, Settings, USER_ROLES) {
+
+  // Set ROLES to rootscope to be used in templates
+  $rootScope.USER_ROLES = USER_ROLES;
 
   // Fetch website configs (title, keywords, desc...)
   Settings.webConfigs().$promise

--- a/app/config.js
+++ b/app/config.js
@@ -38,7 +38,7 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
         $title: ['$stateParams', function($stateParams) {
           return $stateParams.username;
         }],
-        user: [ 'User', '$stateParams', '$state', function(User, $stateParams, $state) {
+        user: [ 'User', '$stateParams', function(User, $stateParams) {
           return User.get({ id: $stateParams.username }).$promise
           .then(function(user) { return user; });
         }]

--- a/app/posts/posts.data.html
+++ b/app/posts/posts.data.html
@@ -1,4 +1,4 @@
-<div class="row post-block" ng-class="{ 'admin': post.user.role === 'Administrator', 'global-mod': post.user.role === 'Global Moderator', 'mod': post.user.role === 'Moderator' }"
+<div class="row post-block" ng-class="{ 'admin': post.user.role === USER_ROLES.admin || post.user.role === USER_ROLES.superAdmin, 'global-mod': post.user.role === USER_ROLES.globalMod, 'mod': post.user.role === USER_ROLES.mod }"
 ng-repeat="post in PostsCtrl.posts track by post.id">
   <!-- Post Anchor -->
   <a class="anchor-offset" id="{{post.id}}"></a>

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -2,8 +2,8 @@
 /* jslint node: true */
 /* global angular */
 
-module.exports = ['$window',
-  function($window) {
+module.exports = ['$window', 'USER_ROLES',
+  function($window, USER_ROLES) {
     var user = {};
     var authenticated = false;
     $window.privateStorage = {}; // fallback for safari private browser
@@ -40,13 +40,8 @@ module.exports = ['$window',
       user.roles = newUser.roles || [];
       // user roles
       user.roles.forEach(function(role) {
-        if (role.name === 'Administrator') { user.isAdmin = true; }
-      });
-
-      user.roles.forEach(function(role) {
-        if (role.name === 'Moderator' || role.name === 'Global Moderator') {
-          user.isMod = true;
-       }
+        if (role.name === USER_ROLES.admin || role.name === USER_ROLES.superAdmin) { user.isAdmin = true; }
+        if (role.name === USER_ROLES.mod || role.name === USER_ROLES.globalMod) { user.isMod = true; }
       });
 
       // token storage

--- a/server/routes/admin/reports/config.js
+++ b/server/routes/admin/reports/config.js
@@ -1,7 +1,7 @@
 var Joi = require('joi');
 var path = require('path');
 var Boom = require('boom');
-var commonAdminPre = require(path.normalize(__dirname + '/../../common')).admin;
+var commonAdminPre = require(path.normalize(__dirname + '/../../common')).auth;
 var db = require(path.normalize(__dirname + '/../../../../db'));
 
 // Create Operations

--- a/server/routes/admin/settings/config.js
+++ b/server/routes/admin/settings/config.js
@@ -3,7 +3,7 @@ var Joi = require('joi');
 var path = require('path');
 var _ = require('lodash');
 var renameKeys = require('deep-rename-keys');
-var commonPre = require(path.normalize(__dirname + '/../../common')).admin;
+var commonPre = require(path.normalize(__dirname + '/../../common')).auth;
 var config = require(path.normalize(__dirname + '/../../../../config'));
 
 var writeConfigToEnv = function(updatedConfig) {

--- a/server/routes/admin/users/config.js
+++ b/server/routes/admin/users/config.js
@@ -2,9 +2,10 @@ var Joi = require('joi');
 var path = require('path');
 var Boom = require('boom');
 var commonUsersPre = require(path.normalize(__dirname + '/../../common')).users;
-var commonAdminPre = require(path.normalize(__dirname + '/../../common')).admin;
+var commonAdminPre = require(path.normalize(__dirname + '/../../common')).auth;
 var pre = require(path.normalize(__dirname + '/pre'));
 var db = require(path.normalize(__dirname + '/../../../../db'));
+var USER_ROLES = require(path.normalize(__dirname + '/../../user-roles'));
 
 exports.update = {
   auth: { mode: 'required', strategy: 'jwt' },
@@ -78,7 +79,7 @@ exports.addRoles = {
   validate: {
     payload: {
       user_id: Joi.string().required(),
-      roles: Joi.array().items(Joi.string().valid('User', 'Moderator', 'Global Moderator', 'Administrator', 'Super Administrator').required()).unique().min(1).required()
+      roles: Joi.array().items(Joi.string().valid(USER_ROLES.user, USER_ROLES.mod, USER_ROLES.globalMod, USER_ROLES.admin, USER_ROLES.superAdmin).required()).unique().min(1).required()
     }
   },
   pre: [ { method: commonAdminPre.adminCheck } ],
@@ -96,7 +97,7 @@ exports.removeRoles = {
   validate: {
     payload: {
       user_id: Joi.string().required(),
-      roles: Joi.array().items(Joi.string().valid('User', 'Moderator', 'Global Moderator', 'Administrator', 'Super Administrator').required()).unique().min(1).required()
+      roles: Joi.array().items(Joi.string().valid(USER_ROLES.user, USER_ROLES.mod, USER_ROLES.globalMod, USER_ROLES.admin, USER_ROLES.superAdmin).required()).unique().min(1).required()
     }
   },
   pre: [ { method: commonAdminPre.adminCheck } ],
@@ -135,7 +136,7 @@ exports.count = {
   handler: function(request, reply) {
     var opts;
     var filter = request.query.filter;
-    if (filter) { opts = { filter: filter } }
+    if (filter) { opts = { filter: filter }; }
     db.users.count(opts)
     .then(function(usersCount) { reply(usersCount); });
   }

--- a/server/routes/boards/config.js
+++ b/server/routes/boards/config.js
@@ -1,7 +1,7 @@
 var Joi = require('joi');
 var path = require('path');
-var Hapi = require('hapi');
 var Boom = require('boom');
+var commonPre = require(path.normalize(__dirname + '/../common')).auth;
 var pre = require(path.normalize(__dirname + '/pre'));
 var db = require(path.normalize(__dirname + '/../../../db'));
 
@@ -19,7 +19,7 @@ exports.create = {
   },
   pre: [
     { method: pre.clean },
-    { method: pre.adminCheck }
+    { method: commonPre.adminCheck }
   ],
   handler: function(request, reply) {
     db.boards.create(request.payload)
@@ -98,7 +98,7 @@ exports.allCategories = {
 
 exports.updateCategories = {
   auth: { mode: 'required', strategy: 'jwt' },
-  pre: [ { method: pre.adminCheck } ],
+  pre: [ { method: commonPre.adminCheck } ],
   validate: {
     payload: {
       categories: Joi.array().required(),
@@ -128,7 +128,7 @@ exports.update = {
   },
   pre: [
     { method: pre.clean },
-    { method: pre.adminCheck }
+    { method: commonPre.adminCheck }
   ],
   handler: function(request, reply) {
     // build updateBoard object from params and payload
@@ -143,7 +143,7 @@ exports.update = {
     // update board on db
     db.boards.update(updateBoard)
     .then(function(board) { reply(board); })
-    .catch(function() { reply(Boom.badImplementation(err)); });
+    .catch(function(err) { reply(Boom.badImplementation(err)); });
   }
 };
 
@@ -157,6 +157,6 @@ exports.delete = {
   handler: function(request, reply) {
     db.boards.delete(request.params.id)
     .then(function(board) { reply(board); })
-    .catch(function() { reply(Boom.badImplementation(err)); });
+    .catch(function(err) { reply(Boom.badImplementation(err)); });
   }
 };

--- a/server/routes/boards/pre.js
+++ b/server/routes/boards/pre.js
@@ -1,7 +1,5 @@
 var path = require('path');
-var Boom = require('boom');
-var db = require(path.normalize(__dirname + '/../../../db'));
-var config = require(path.normalize(__dirname + '/../../../config'));
+
 var sanitizer = require(path.normalize(__dirname + '/../../sanitizer'));
 
 module.exports = {
@@ -11,22 +9,5 @@ module.exports = {
       request.payload.description = sanitizer.display(request.payload.description);
     }
     return reply();
-  },
-  adminCheck: function(request, reply) {
-    var userId = request.auth.credentials.id;
-    var error = Boom.unauthorized('You must be an admin to perform this action.');
-    db.users.find(userId)
-    .then(function(user) {
-      if (!user) { return reply(error); }
-      var isAdmin = false;
-      user.roles.forEach(function(role) {
-        if (role.name === 'Administrator') { isAdmin = true; }
-      });
-      if (isAdmin) { reply(); }
-      else { return reply(error); }
-    })
-    .catch(function() {
-      return reply(error);
-    });
-  },
+  }
 };

--- a/server/routes/common.js
+++ b/server/routes/common.js
@@ -5,9 +5,10 @@ var bbcodeParser = require('epochtalk-bbcode-parser');
 var sanitizer = require(path.normalize(__dirname + '/../sanitizer'));
 var imageStore = require(path.normalize(__dirname + '/../images'));
 var db = require(path.normalize(__dirname + '/../../db'));
+var USER_ROLES = require(path.normalize(__dirname + '/user-roles'));
 
 module.exports = {
-  admin: {
+  auth: {
     adminCheck: function(request, reply) {
       if (request.auth.isAuthenticated) {
         var username = request.auth.credentials.username;
@@ -15,7 +16,7 @@ module.exports = {
         .then(function(user) {
           var isAdmin = false;
           user.roles.forEach(function(role) {
-            if (role.name === 'Administrator' || role.name === 'Super Administrator') { isAdmin = true; }
+            if (role.name === USER_ROLES.admin || role.name === USER_ROLES.superAdmin) { isAdmin = true; }
           });
           return reply(isAdmin || Boom.unauthorized());
         })
@@ -31,8 +32,8 @@ module.exports = {
           var isMod = false;
           var isAdmin = false;
           user.roles.forEach(function(role) {
-            if (role.name === 'Moderator' || role.name === 'Global Moderator') { isMod = true; }
-            if (role.name === 'Administrator' || role.name === 'Super Administrator') { isAdmin = true; }
+            if (role.name === USER_ROLES.mod || role.name === USER_ROLES.globalMod) { isMod = true; }
+            if (role.name === USER_ROLES.admin || role.name === USER_ROLES.superAdmin) { isAdmin = true; }
           });
           if (isMod) { return reply(true); }
           else if (isAdmin) { return reply(false); } // Admin is not unauthorized, fall through to adminCheck

--- a/server/routes/posts/config.js
+++ b/server/routes/posts/config.js
@@ -159,7 +159,7 @@ exports.pageByUserCount = {
     var username = request.params.username;
     db.posts.pageByUserCount(username)
     .then(function(count) { reply(count); })
-    .catch(function(err) { console.log(err); reply(Boom.badImplementation(err)); });
+    .catch(function(err) { reply(Boom.badImplementation(err)); });
   }
 };
 

--- a/server/routes/posts/pre.js
+++ b/server/routes/posts/pre.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var Hapi = require('hapi');
 var Boom = require('boom');
 var cheerio = require('cheerio');
 var Promise = require('bluebird');

--- a/server/routes/threads/config.js
+++ b/server/routes/threads/config.js
@@ -1,8 +1,8 @@
 var Joi = require('joi');
 var path = require('path');
-var Hapi = require('hapi');
 var Boom = require('boom');
 var pre = require(path.normalize(__dirname + '/pre'));
+var commonPre = require(path.normalize(__dirname + '/../common')).auth;
 var db = require(path.normalize(__dirname + '/../../../db'));
 var postPre = require(path.normalize(__dirname + '/../posts/pre'));
 
@@ -135,18 +135,12 @@ exports.lock = {
   },
   pre: [
     { method: pre.getThread, assign: 'thread' },
-    { method: pre.isAdmin, assign: 'isAdmin' }
+    { method: pre.threadAuthorCheck || commonPre.adminCheck, assign: 'canLock' }
   ],
   handler: function(request, reply) {
-    var thisUserId = request.auth.credentials.id;
     var thread = request.pre.thread;
-    var isAdmin = request.pre.isAdmin;
-    var canLock = false;
+    var canLock = request.pre.canLock;
     var promise;
-
-    // check if thread is lockable by user
-    if (isAdmin) { canLock = true; }
-    else if (thread.user.id === thisUserId) { canLock = true; }
 
     // lock thread
     if (canLock) {
@@ -168,7 +162,7 @@ exports.sticky = {
   },
   pre: [
     { method: pre.getThread, assign: 'thread' },
-    { method: pre.isAdmin, assign: 'isAdmin' }
+    { method: commonPre.adminCheck, assign: 'isAdmin' }
   ],
   handler: function(request, reply) {
     var thread = request.pre.thread;
@@ -195,7 +189,7 @@ exports.move = {
   },
   pre: [
     { method: pre.getThread, assign: 'thread' },
-    { method: pre.isAdmin, assign: 'isAdmin' }
+    { method: commonPre.adminCheck, assign: 'isAdmin' }
   ],
   handler: function(request, reply) {
     var thread = request.pre.thread;

--- a/server/routes/threads/pre.js
+++ b/server/routes/threads/pre.js
@@ -2,8 +2,7 @@ var path = require('path');
 var uuid = require('node-uuid');
 var db = require(path.normalize(__dirname + '/../../../db'));
 var memDb = require(path.normalize(__dirname + '/../../memstore')).db;
-var config = require(path.normalize(__dirname + '/../../../config'));
-
+var Boom = require('boom');
 // Helpers
 var checkViewKey = function(key) {
   return memDb.getAsync(key)
@@ -107,19 +106,9 @@ module.exports = {
     .then(function() { return reply(); })
     .catch(function(err) { return reply(err); });
   },
-  isAdmin: function(request, reply) {
-    if (!request.auth.isAuthenticated) { return reply(Boom.unauthorized()); }
-    else {
-      var username = request.auth.credentials.username;
-      var isAdmin = false;
-      return db.users.userByUsername(username)
-      .then(function(user) {
-        user.roles.forEach(function(role) {
-          if (role.name === 'Administrator') { isAdmin = true; }
-        });
-        return reply(isAdmin);
-      })
-      .catch(function() { return reply(isAdmin); });
-    }
+  threadAuthorCheck: function(request, reply) {
+    var authorUserId = request.pre.thread.user.id;
+    var authedUserId = request.auth.credentials.id;
+    reply(authorUserId === authedUserId);
   }
 };

--- a/server/routes/user-roles.js
+++ b/server/routes/user-roles.js
@@ -1,0 +1,7 @@
+module.exports = {
+  user: 'User',
+  mod: 'Moderator',
+  globalMod: 'Global Moderator',
+  admin: 'Administrator',
+  superAdmin: 'Super Administrator'
+};


### PR DESCRIPTION
* Using angular constants 'USER_ROLES' to declare user roles to be used
  throughout the client side code. This stops the string compare for roles
  from getting out of control. Replaced all string instances of role names
  such as 'Administrator', 'Global Moderator', etc in the client side code
  with their respective constants. Added 'USER_ROLES' constants to
  rootScope for use in the templates where role string comparisons were
  being performed.

* Added user-roles.js to the /server/routes folder. This file exports
  the same data declared in the angular constant 'USER_ROLES'. Replaced
  all role string compares in templates with 'USER_ROLES' constants.

* Added fix for confirm button unlocking too soon after adding a new
  moderator or new admin.

* Added super admin check for css post outline in posts.data.html. Super
  admins might have different css in the future, but for now it shows
  the same outline color as admins.

* Removed duplicate adminCheck pre methods. As a result, in common.js in
  the /server/routes folder changed the 'admin' property to auth',
  since the admin and mod pre checks are being used in more than just the
  admin routes now.

* Added missing err parameter to catch in boards.update and boards.delete.

* Removed console.log from pageByUserCount in posts route config.