### PR TITLE
Board mapping

### DIFF
--- a/app/board/board.controller.js
+++ b/app/board/board.controller.js
@@ -16,6 +16,30 @@ module.exports = ['$rootScope', '$scope', '$anchorScroll', '$location', '$timeou
     this.parent.pageCount = Math.ceil(board.thread_count / threadLimit);
     this.parent.newThreadUrl = '/boards/' + board.id + '/threads/new';
 
+    // set total_thread_count and total_post_count for all boards
+    board.children.map(function(childBoard) {
+      var children = countTotals(childBoard.children);
+      childBoard.total_thread_count = children.thread_count + childBoard.thread_count;
+      childBoard.total_post_count = children.post_count + childBoard.post_count;
+    });
+
+    function countTotals(countBoards) {
+      var thread_count = 0;
+      var post_count = 0;
+
+      if (countBoards.length > 0) {
+        countBoards.forEach(function(countBoard) {
+          var children = countTotals(countBoard.children);
+          thread_count += children.thread_count + countBoard.thread_count;
+          post_count += children.post_count + countBoard.post_count;
+          countBoard.total_thread_count = thread_count;
+          countBoard.total_post_count = post_count;
+        });
+      }
+
+      return {thread_count: thread_count, post_count: post_count};
+    }
+
     // generate page listing for each thread
     this.getPageKeysForThread = function(thread) {
       var pageKeys = [];

--- a/app/boards/boards.controller.js
+++ b/app/boards/boards.controller.js
@@ -3,21 +3,18 @@ var _ = require('lodash');
 module.exports = ['$timeout', '$anchorScroll', 'boards',
   function($timeout, $anchorScroll, boards) {
     var ctrl = this;
+    this.categorizedBoards = boards;
     this.toggles = {};
-
-    // sort categories by view_order
-    var sortedCats = _.sortBy(boards, function(cat) { return cat.view_order; });
-    this.categorizedBoards = sortedCats;
 
     // Category toggling
     var i = 0;
-    sortedCats.forEach(function() { ctrl.toggles[i++] = false; });
+    this.categorizedBoards.forEach(function() { ctrl.toggles[i++] = false; });
     this.toggle = function(index){
       ctrl.toggles[index] = !ctrl.toggles[index];
     };
 
     // set total_thread_count and total_post_count for all boards
-    sortedCats.map(function(category) {
+    this.categorizedBoards.map(function(category) {
       var boards = category.boards;
       boards.map(function(board) {
         var children = countTotals(board.children);

--- a/app/boards/boards.controller.js
+++ b/app/boards/boards.controller.js
@@ -3,17 +3,46 @@ var _ = require('lodash');
 module.exports = ['$timeout', '$anchorScroll', 'boards',
   function($timeout, $anchorScroll, boards) {
     var ctrl = this;
-
     this.toggles = {};
 
+    // sort categories by view_order
     var sortedCats = _.sortBy(boards, function(cat) { return cat.view_order; });
     this.categorizedBoards = sortedCats;
+
+    // Category toggling
     var i = 0;
     sortedCats.forEach(function() { ctrl.toggles[i++] = false; });
-    $timeout($anchorScroll);
-
     this.toggle = function(index){
       ctrl.toggles[index] = !ctrl.toggles[index];
     };
+
+    // set total_thread_count and total_post_count for all boards
+    sortedCats.map(function(category) {
+      var boards = category.boards;
+      boards.map(function(board) {
+        var children = countTotals(board.children);
+        board.total_thread_count = children.thread_count + board.thread_count;
+        board.total_post_count = children.post_count + board.post_count;
+      });
+    });
+
+    function countTotals(countBoards) {
+      var thread_count = 0;
+      var post_count = 0;
+
+      if (countBoards.length > 0) {
+        countBoards.forEach(function(board) {
+          var children = countTotals(board.children);
+          thread_count += children.thread_count + board.thread_count;
+          post_count += children.post_count + board.post_count;
+          board.total_thread_count = thread_count;
+          board.total_post_count = post_count;
+        });
+      }
+
+      return {thread_count: thread_count, post_count: post_count};
+    }
+
+    $timeout($anchorScroll);
   }
 ];

--- a/app/boards/boards.html
+++ b/app/boards/boards.html
@@ -51,15 +51,15 @@
 
         <!-- Board Last Post By -->
         <div class="last-post small-6 medium-3 columns text-info">
-          <div>
+          <div ng-if="board.last_post_username">
             Last post by
             <a ng-href="/profiles/{{ board.last_post_username }}" ng-bind-html="board.last_post_username"></a>
           </div>
-          <div>
+          <div ng-if="board.last_thread_title">
             in thread
             <a ng-href="/threads/{{board.last_thread_id}}/posts" ng-bind-html="board.last_thread_title | truncate:25"></a>
           </div>
-          <div>
+          <div ng-if="board.last_post_created_at">
             <i ng-bind="board.last_post_created_at | humanDate"></i>
           </div>
         </div>

--- a/app/components/category_editor/nestable-boards.directive.js
+++ b/app/components/category_editor/nestable-boards.directive.js
@@ -25,13 +25,12 @@ module.exports = ['$compile', function($compile) {
           scope.nestableMap[dataId] = {
             id: board.id,
             name: board.name,
-            description: board.description,
-            children_ids: board.children_ids || []
+            description: board.description
           };
           var toolbarHtml = '<i data-reveal-id="edit-board" ng-click="setEditBoard(' +
             dataId + ')" class="dd-nodrag dd-right-icon fa fa-pencil"></i>';
           var status = '<i class="fa status"></i>';
-          html += '<li class="dd-item" data-id="' + dataId + '"><div class="dd-grab"></div>' +
+          html += '<li class="dd-item" data-board-id="' + board.id + '" data-id="' + dataId + '"><div class="dd-grab"></div>' +
             '<div class="dd-handle">' + status + '<div class="dd-desc">' + board.name +  '<span>' + board.description + '</span></div>' +
             toolbarHtml + '</div>' + generateBoardList(board.children) + '</li>';
         });
@@ -41,15 +40,9 @@ module.exports = ['$compile', function($compile) {
 
       // Generates nestable html for uncategorized boards
       var generateNoCatBoardsList = function(boards) {
-        var noCatBoards = [];
-        boards.forEach(function(board) {
-          if (!board.category_id && board.category_id !== 0) {
-            noCatBoards.push(board);
-          }
-        });
         var emptyHtml = '<div class="dd-empty"></div>';
         var html = '<div class="dd" id="' + scope.boardListId + '">';
-        html += noCatBoards.length > 0 ? generateBoardList(noCatBoards) : emptyHtml;
+        html += boards.length > 0 ? generateBoardList(boards) : emptyHtml;
         html += '</div>';
         return html;
       };
@@ -66,8 +59,7 @@ module.exports = ['$compile', function($compile) {
           scope.nestableMap[dataId] = {
             id: -1,
             name: board.name,
-            description: board.description,
-            children_ids: [],
+            description: board.description
           };
           // Add dataId to board before adding to new boards array
           // to allow for quick lookup in nestableMap from parent controller

--- a/app/components/category_editor/nestable-boards.directive.js
+++ b/app/components/category_editor/nestable-boards.directive.js
@@ -16,7 +16,6 @@ module.exports = ['$compile', function($compile) {
 
       // Generates nestable html elements for board data
       var generateBoardList = function(boards) {
-        if (!boards) { return ''; }
         var html = '<ol class="dd-list">';
         boards.forEach(function(board) {
           var dataId = scope.getDataId();
@@ -25,14 +24,15 @@ module.exports = ['$compile', function($compile) {
           scope.nestableMap[dataId] = {
             id: board.id,
             name: board.name,
-            description: board.description
+            description: board.description,
+            children: board.children || []
           };
           var toolbarHtml = '<i data-reveal-id="edit-board" ng-click="setEditBoard(' +
             dataId + ')" class="dd-nodrag dd-right-icon fa fa-pencil"></i>';
           var status = '<i class="fa status"></i>';
           html += '<li class="dd-item" data-board-id="' + board.id + '" data-id="' + dataId + '"><div class="dd-grab"></div>' +
             '<div class="dd-handle">' + status + '<div class="dd-desc">' + board.name +  '<span>' + board.description + '</span></div>' +
-            toolbarHtml + '</div>' + generateBoardList(board.children) + '</li>';
+            toolbarHtml + '</div>' + generateBoardList(board.children || []) + '</li>';
         });
         html += '</ol>';
         return html;
@@ -59,7 +59,8 @@ module.exports = ['$compile', function($compile) {
           scope.nestableMap[dataId] = {
             id: -1,
             name: board.name,
-            description: board.description
+            description: board.description,
+            children: board.children || []
           };
           // Add dataId to board before adding to new boards array
           // to allow for quick lookup in nestableMap from parent controller

--- a/app/components/category_editor/nestable-categories.directive.js
+++ b/app/components/category_editor/nestable-categories.directive.js
@@ -19,7 +19,7 @@ module.exports = ['$compile', function($compile) {
       // Generates nestable html for category data
       var generateCategoryList = function(categories) {
         var html = '<div class="dd" id="' + scope.catListId + '"><ol class="dd-list">';
-        var sortedCats = _.sortBy(categories, function(cat) { return cat.view_order; });
+        var sortedCats = _.sortBy(categories, 'view_order');
         sortedCats.forEach(function(cat) {
           var dataId = scope.getDataId();
           var boardIds = [];
@@ -28,7 +28,7 @@ module.exports = ['$compile', function($compile) {
           scope.nestableMap[dataId] = {
             id: cat.id,
             name: cat.name,
-            children_ids: boardIds
+            children: catBoards
           };
           // Edit pencil and trash buttons
           var toolbarHtml = '<i data-reveal-id="delete-confirm" ng-click="setDelete(' + dataId + ')" class="dd-nodrag dd-right-icon fa fa-trash"></i>' +
@@ -56,12 +56,12 @@ module.exports = ['$compile', function($compile) {
             id: board.id,
             name: board.name,
             description: board.description,
-            children_ids: board.children_ids || []
+            children: board.children || []
           };
           var toolbarHtml = '<i data-reveal-id="edit-board" ng-click="setEditBoard(' +
             dataId + ')" class="dd-nodrag dd-right-icon fa fa-pencil"></i>';
           var status = '<i class="fa status"></i>';
-          html += '<li class="dd-item" data-id="' + dataId + '">' +
+          html += '<li class="dd-item" data-board-id="' + board.id + '" data-id="' + dataId + '">' +
             '<div class="dd-grab"></div><div class="dd-handle">' + status + '<div class="dd-desc">' + board.name + '<span>' + board.description + '</span></div>' +
             toolbarHtml + '</div>' + generateBoardList(board.children) + '</li>';
         });
@@ -74,10 +74,7 @@ module.exports = ['$compile', function($compile) {
         if (catName) {
           var dataId = scope.getDataId();
           // Update hashmap of list items
-          scope.nestableMap[dataId] = {
-            name: catName,
-            children_ids: []
-          };
+          scope.nestableMap[dataId] = { name: catName };
 
           // Edit pencil and trash buttons
           var toolbarHtml = '<i data-reveal-id="delete-confirm" ng-click="setDelete(' + dataId + ')" class="dd-nodrag dd-right-icon fa fa-trash"></i>' +

--- a/app/components/category_editor/nestable-categories.directive.js
+++ b/app/components/category_editor/nestable-categories.directive.js
@@ -46,7 +46,6 @@ module.exports = ['$compile', function($compile) {
 
       // Generates nestable html elements for board data
       var generateBoardList = function(boards) {
-        if (!boards) { return ''; }
         var html = '<ol class="dd-list">';
         boards.forEach(function(board) {
           var dataId = scope.getDataId();
@@ -63,27 +62,30 @@ module.exports = ['$compile', function($compile) {
           var status = '<i class="fa status"></i>';
           html += '<li class="dd-item" data-board-id="' + board.id + '" data-id="' + dataId + '">' +
             '<div class="dd-grab"></div><div class="dd-handle">' + status + '<div class="dd-desc">' + board.name + '<span>' + board.description + '</span></div>' +
-            toolbarHtml + '</div>' + generateBoardList(board.children) + '</li>';
+            toolbarHtml + '</div>' + generateBoardList(board.children || []) + '</li>';
         });
         html += '</ol>';
         return html;
       };
 
       scope.insertNewCategory = function() {
-        var catName = scope.newCatName;
-        if (catName) {
+        var category = { name: scope.newCatName };
+
+        if (category.name !== '') {
           var dataId = scope.getDataId();
           // Update hashmap of list items
-          scope.nestableMap[dataId] = { name: catName };
+          scope.nestableMap[dataId] = { id: -1, name: category.name };
+          category.dataId = dataId;
+          scope.newCategories.push(category);
 
           // Edit pencil and trash buttons
           var toolbarHtml = '<i data-reveal-id="delete-confirm" ng-click="setDelete(' + dataId + ')" class="dd-nodrag dd-right-icon fa fa-trash"></i>' +
             '<i data-reveal-id="edit-category" ng-click="setEditCat(' +
               dataId + ')" class="dd-nodrag dd-right-icon fa fa-pencil"></i>';
           var status = '<i class="fa status modified"></i>';
-          var newCatHtml = '<li class="dd-item dd-root-item" data-cat-id="' + -1 + '"  data-id="' + dataId +
-            '" data-top="true" data-name="' + catName + '"><div class="dd-grab-cat"></div><div class="dd-handle dd-root-handle">' +
-            status + '<div class="dd-desc">' + catName + '</div>' + toolbarHtml + '</div></li>';
+          var newCatHtml = '<li class="dd-item dd-root-item" data-cat-id="' + -1 + '"  data-id="' + dataId + '" data-top="true" data-name="' + category.name +
+            '"><div class="dd-grab-cat"></div><div class="dd-handle dd-root-handle">' +
+            status + '<div class="dd-desc">' + category.name + '</div>' + toolbarHtml + '</div></li>';
 
           // Compile and prepend new category html
           newCatHtml = $compile(newCatHtml)(scope);

--- a/app/resources/categories.js
+++ b/app/resources/categories.js
@@ -1,0 +1,18 @@
+'use strict';
+/* jslint node: true */
+
+module.exports = ['$resource',
+  function($resource) {
+    return $resource('/api/categories/:id', {}, {
+      all: {
+        method: 'GET',
+        url: '/api/boards',
+        isArray: true
+      },
+      update: {
+        method: 'POST',
+        params: { id: '@id' }
+      },
+    });
+  }
+];

--- a/app/resources/index.js
+++ b/app/resources/index.js
@@ -3,6 +3,7 @@ require('./admin');
 angular.module('ept')
   .factory('Breadcrumbs', require('./breadcrumbs.js'))
   .factory('Boards', require('./boards.js'))
+  .factory('Categories', require('./categories.js'))
   .factory('Threads', require('./threads.js'))
   .factory('Posts', require('./posts.js'))
   .factory('Reports', require('./reports.js'))

--- a/server/routes/boards/config.js
+++ b/server/routes/boards/config.js
@@ -99,15 +99,11 @@ exports.allCategories = {
 exports.updateCategories = {
   auth: { mode: 'required', strategy: 'jwt' },
   pre: [ { method: commonPre.adminCheck } ],
-  validate: {
-    payload: {
-      categories: Joi.array().required(),
-    }
-  },
+  validate: { payload: { boardMapping: Joi.array().required() } },
   handler: function(request, reply) {
     // update board on db
-    db.boards.updateCategories(request.payload.categories)
-    .then(function(board) { reply(board); })
+    db.boards.updateCategories(request.payload.boardMapping)
+    .then(function(categories) { reply(categories); })
     .catch(function(err) { reply(Boom.badImplementation(err)); });
   }
 };


### PR DESCRIPTION
Added a new intersection table to list all the mappings between categories and boards and between parent boards and children boards. The boards.find method was also updated to return children boards. 

This pull request must be tested with the board-mapping branch in epochtalk/epochtalk.

To test this pull request, run the db-migration and update the category with boards. 
  * Create a new category and save
  * Create a new board and save
  * Create a new category and a new board and save
  * Nest boards at least two levels deep and save

Ensure that all changes are reflected on the front page and in board's page as well. Things to look out for: 
  * thread count and post count should exists and show count child counts as well
  * on a board's page, ensure that any children boards appear, along with said counts
  * board moderators are not implemented yet.
