### PR TITLE
Fix for undefined error when checking length of child boards

### DIFF
--- a/app/admin/management/boards.controller.js
+++ b/app/admin/management/boards.controller.js
@@ -25,7 +25,7 @@ module.exports = ['$scope', '$q', 'Boards', 'Categories', 'boards', 'categories'
         // remove this board from boardListData
         _.remove(boards, function(tempBoard) { return tempBoard.id === board.id; });
         // recurse if there are children
-        if (board.children.length > 0) { cleanBoards(board.children); }
+        if (board.children && board.children.length > 0) { cleanBoards(board.children); }
       });
     }
 

--- a/app/board/board.controller.js
+++ b/app/board/board.controller.js
@@ -17,17 +17,19 @@ module.exports = ['$rootScope', '$scope', '$anchorScroll', '$location', '$timeou
     this.parent.newThreadUrl = '/boards/' + board.id + '/threads/new';
 
     // set total_thread_count and total_post_count for all boards
-    board.children.map(function(childBoard) {
-      var children = countTotals(childBoard.children);
-      childBoard.total_thread_count = children.thread_count + childBoard.thread_count;
-      childBoard.total_post_count = children.post_count + childBoard.post_count;
-    });
+    if (board.children) {
+      board.children.map(function(childBoard) {
+        var children = countTotals(childBoard.children);
+        childBoard.total_thread_count = children.thread_count + childBoard.thread_count;
+        childBoard.total_post_count = children.post_count + childBoard.post_count;
+      });
+    }
 
     function countTotals(countBoards) {
       var thread_count = 0;
       var post_count = 0;
 
-      if (countBoards.length > 0) {
+      if (countBoards && countBoards.length > 0) {
         countBoards.forEach(function(countBoard) {
           var children = countTotals(countBoard.children);
           thread_count += children.thread_count + countBoard.thread_count;

--- a/app/boards/boards.controller.js
+++ b/app/boards/boards.controller.js
@@ -27,7 +27,7 @@ module.exports = ['$timeout', '$anchorScroll', 'boards',
       var thread_count = 0;
       var post_count = 0;
 
-      if (countBoards.length > 0) {
+      if (countBoards && countBoards.length > 0) {
         countBoards.forEach(function(board) {
           var children = countTotals(board.children);
           thread_count += children.thread_count + board.thread_count;


### PR DESCRIPTION
* When starting with a fresh clone and fresh db. There is an error
  being thrown in console because board.children.length was being
  checked and board.children was undefined. This was causing both
  the main forum page (boards) and the category editor in the admin
  panel to break. This commit resolves the issue.