### PR TITLE
Added alerts to admin pages. Added filters to reports.

### DIFF
--- a/app/admin/management/administrators.controller.js
+++ b/app/admin/management/administrators.controller.js
@@ -1,8 +1,9 @@
-module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminUsers', 'admins', 'adminsCount', 'page', 'limit', 'field', 'desc', 'USER_ROLES', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminUsers, admins, adminsCount, page, limit, field, desc, USER_ROLES) {
+module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Alert', 'Session', 'AdminUsers', 'admins', 'adminsCount', 'page', 'limit', 'field', 'desc', 'USER_ROLES', function($rootScope, $scope, $location, $timeout, $anchorScroll, Alert, Session, AdminUsers, admins, adminsCount, page, limit, field, desc, USER_ROLES) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'administrators';
   this.admins = admins;
+  this.count = adminsCount;
   this.pageCount =  Math.ceil(adminsCount / limit);
   this.admins = admins;
   this.queryParams = $location.search();
@@ -44,7 +45,10 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       if (role.name === USER_ROLES.admin || role.name === USER_ROLES.superAdmin) { hasAdminRole = true; }
     });
 
-    if (hasAdminRole) { ctrl.closeConfirmAdd(); }
+    if (hasAdminRole) {
+      Alert.warning(ctrl.selectedUser.username + ' is already in the list of administrators');
+      ctrl.closeConfirmAdd();
+    }
     else {
       var roles = [ USER_ROLES.admin ]; // default to admin role
       if (ctrl.selectedRole === USER_ROLES.superAdmin) { // Append super admin role if selected
@@ -56,6 +60,8 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       };
       AdminUsers.addRoles(params).$promise
       .then(function() {
+        var messageEnding = ctrl.selectedRole === USER_ROLES.superAdmin ? ' ' + USER_ROLES.superAdmin : 'n ' + USER_ROLES.admin;
+        Alert.success(ctrl.selectedUser.username + ' has been added as a' + messageEnding);
         ctrl.closeConfirmAdd();
         ctrl.pullPage();
       });
@@ -92,6 +98,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     };
     AdminUsers.removeRoles(params).$promise
     .then(function() {
+      Alert.success(ctrl.selectedUser.username + ' has been removed from administrators');
       ctrl.pullPage();
       ctrl.closeConfirmRemove();
     });
@@ -199,6 +206,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     // update admin's page count
     AdminUsers.countAdmins().$promise
     .then(function(updatedCount) {
+      ctrl.count = updatedCount.count;
       ctrl.pageCount = Math.ceil(updatedCount.count / limit);
     });
 

--- a/app/admin/management/administrators.html
+++ b/app/admin/management/administrators.html
@@ -4,7 +4,10 @@
   </div>
   <div class="admin-table-fix"></div>
 </div>
-<div class="row full-width">
+<div class="row full-width" align="center" ng-if="AdminManagementCtrl.count < 1">
+  <h4>No Administrators to display</h4>
+</div>
+<div class="row full-width" ng-if="AdminManagementCtrl.count > 0">
   <div class="small-12 columns">
     <table width="100%">
       <thead>

--- a/app/admin/management/boards.controller.js
+++ b/app/admin/management/boards.controller.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 
-module.exports = ['$scope', '$q', 'Boards', 'Categories', 'boards', 'categories',
-  function($scope, $q, Boards, Categories, boards, categories) {
+module.exports = ['$location', '$stateParams', '$scope', '$q', '$anchorScroll', 'Alert', 'Boards', 'Categories', 'boards', 'categories',
+  function($location, $stateParams, $scope, $q, $anchorScroll, Alert, Boards, Categories, boards, categories) {
     this.parent = $scope.$parent;
     this.parent.tab = 'boards';
 
@@ -14,6 +14,13 @@ module.exports = ['$scope', '$q', 'Boards', 'Categories', 'boards', 'categories'
     $scope.newCategories = [];
     $scope.updatedCats = [];
     $scope.boardMapping = [];
+
+    // temporary hack to get save alert working
+    if ($stateParams.saved === 'true') { // string compare to query string
+      $location.search({});
+      Alert.success('Boards successfully saved.');
+    }
+    $anchorScroll();
 
     function cleanBoardList() {
       categories.forEach(function(cat) { return cleanBoards(cat.boards); });

--- a/app/admin/management/moderators.controller.js
+++ b/app/admin/management/moderators.controller.js
@@ -1,7 +1,8 @@
-module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminUsers', 'moderators', 'moderatorsCount', 'page', 'limit', 'field', 'desc', 'USER_ROLES', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminUsers, moderators, moderatorsCount, page, limit, field, desc, USER_ROLES) {
+module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Alert', 'Session', 'AdminUsers', 'moderators', 'moderatorsCount', 'page', 'limit', 'field', 'desc', 'USER_ROLES', function($rootScope, $scope, $location, $timeout, $anchorScroll, Alert, Session, AdminUsers, moderators, moderatorsCount, page, limit, field, desc, USER_ROLES) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'moderators';
+  this.count = moderatorsCount;
   this.pageCount =  Math.ceil(moderatorsCount / limit);
   this.moderators = moderators;
   this.queryParams = $location.search();
@@ -43,7 +44,10 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       if (role.name === USER_ROLES.mod || role.name === USER_ROLES.globalMod) { hasModRole = true; }
     });
 
-    if (hasModRole) { ctrl.closeConfirmAdd(); }
+    if (hasModRole) {
+      Alert.warning(ctrl.selectedUser.username + ' is already in the list of moderators');
+      ctrl.closeConfirmAdd();
+    }
     else {
       var roles = [ USER_ROLES.mod ]; // default to mod role
       if (ctrl.selectedRole === USER_ROLES.globalMod) { // Append global mod role if selected
@@ -55,6 +59,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       };
       AdminUsers.addRoles(params).$promise
       .then(function() {
+        Alert.success(ctrl.selectedUser.username + ' has been added as a ' + ctrl.selectedRole);
         ctrl.closeConfirmAdd();
         ctrl.pullPage();
       });
@@ -91,6 +96,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     };
     AdminUsers.removeRoles(params).$promise
     .then(function() {
+      Alert.success(ctrl.selectedUser.username + ' has been removed from moderators');
       ctrl.pullPage();
       ctrl.closeConfirmRemove();
     });
@@ -194,6 +200,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     // update mods's page count
     AdminUsers.countModerators().$promise
     .then(function(updatedCount) {
+      ctrl.count = updatedCount.count;
       ctrl.pageCount = Math.ceil(updatedCount.count / limit);
     });
 

--- a/app/admin/management/moderators.html
+++ b/app/admin/management/moderators.html
@@ -4,7 +4,10 @@
   </div>
   <div class="admin-table-fix"></div>
 </div>
-<div class="row full-width">
+<div class="row full-width" align="center" ng-if="AdminManagementCtrl.count < 1">
+  <h4>No Moderators to display</h4>
+</div>
+<div class="row full-width" ng-if="AdminManagementCtrl.count > 0">
   <div class="small-12 columns">
     <table width="100%">
       <thead>

--- a/app/admin/management/users.controller.js
+++ b/app/admin/management/users.controller.js
@@ -1,4 +1,4 @@
-module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', '$filter', 'AdminUsers', 'users', 'usersCount', 'page', 'limit', 'field', 'desc', 'filter', 'search', function($rootScope, $scope, $location, $timeout, $anchorScroll, $filter, AdminUsers, users, usersCount, page, limit, field, desc, filter, search) {
+module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', '$filter', 'Alert', 'AdminUsers', 'users', 'usersCount', 'page', 'limit', 'field', 'desc', 'filter', 'search', function($rootScope, $scope, $location, $timeout, $anchorScroll, $filter, Alert, AdminUsers, users, usersCount, page, limit, field, desc, filter, search) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'users';
@@ -68,7 +68,9 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     AdminUsers.update(ctrl.selectedUser).$promise
     .then(function() {
       ctrl.closeEditUser();
-    });
+      Alert.success('Successfully updated profile for ' + ctrl.selectedUser.username);
+    })
+    .catch(function() { Alert.error('There was an error updating user ' + ctrl.selectedUser.username); });
   };
 
   this.minDate = function() {
@@ -106,6 +108,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     .then(function(ban) {
       if (ctrl.tableFilter === 0) { ctrl.pullPage(); }
       else { ctrl.selectedUser.ban_expiration = ban.expiration; }
+      Alert.success(ctrl.selectedUser.username + ' has been banned');
       ctrl.closeConfirmBan();
       $timeout(function() { // wait for modal to close
         ctrl.confirmBanBtnLabel = 'Confirm';
@@ -135,6 +138,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     .then(function() {
       if (ctrl.tableFilter === 0) { ctrl.pullPage(); }
       else { ctrl.selectedUser.ban_expiration = null; }
+      Alert.success(ctrl.selectedUser.username + ' has been unbanned');
       ctrl.closeConfirmUnban();
       $timeout(function() { // wait for modal to close
         ctrl.confirmBanBtnLabel = 'Confirm';

--- a/app/admin/management/users.html
+++ b/app/admin/management/users.html
@@ -17,7 +17,10 @@
   </div>
   <div class="admin-table-fix"></div>
 </div>
-<div class="row full-width">
+<div class="row full-width" align="center" ng-if="!AdminManagementCtrl.search && AdminManagementCtrl.count < 1">
+  <h4>No Users to display in <strong>{{AdminManagementCtrl.filter ? 'Banned' : 'All'}}</strong></h4>
+</div>
+<div class="row full-width" ng-if="AdminManagementCtrl.count > 0 || AdminManagementCtrl.search">
   <div class="small-12 columns">
     <div ng-if="AdminManagementCtrl.search">
     Displaying {{AdminManagementCtrl.count | number}} search result(s) for "<strong>{{AdminManagementCtrl.search}}</strong>" in <strong>{{AdminManagementCtrl.filter ? 'Banned': 'All'}}</strong>:<br /><br />

--- a/app/admin/moderation/posts.controller.js
+++ b/app/admin/moderation/posts.controller.js
@@ -1,4 +1,4 @@
-module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminReports', 'AdminUsers', 'Posts', 'postReports', 'reportCount', 'page', 'limit', 'field', 'desc', 'filter', 'search', 'reportId', function($rootScope, $scope, $location, $timeout, $anchorScroll, Session, AdminReports, AdminUsers, Posts, postReports, reportCount, page, limit, field, desc, filter, search, reportId) {
+module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScroll', 'Alert', 'Session', 'AdminReports', 'AdminUsers', 'Posts', 'postReports', 'reportCount', 'page', 'limit', 'field', 'desc', 'filter', 'search', 'reportId', function($rootScope, $scope, $location, $timeout, $anchorScroll, Alert, Session, AdminReports, AdminUsers, Posts, postReports, reportCount, page, limit, field, desc, filter, search, reportId) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'posts';
@@ -9,6 +9,8 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
   this.tableFilter = 0;
   if (filter === 'Pending') { this.tableFilter = 1; }
   else if (filter === 'Reviewed') { this.tableFilter = 2; }
+  else if (filter === 'Ignored') { this.tableFilter = 3; }
+  else if (filter === 'Bad Report') { this.tableFilter = 4; }
 
   // Search Vars
   this.search = search;
@@ -108,6 +110,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
         ctrl.previewReport.status = updatedReport.status;
         ctrl.previewReport.updated_at = updatedReport.updated_at;
       }
+      Alert.success('Report status has been set to ' + updatedReport.status);
       $timeout(function() { ctrl.closeSetStatus(); });
       return;
     })
@@ -163,6 +166,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     };
     AdminUsers.ban(params).$promise
     .then(function() {
+      Alert.success(ctrl.selectedUser.username + ' has been banned');
       ctrl.closeConfirmBan();
       ctrl.pullPage();
       $timeout(function() { // wait for modal to close
@@ -191,6 +195,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     };
     AdminUsers.unban(params).$promise
     .then(function() {
+      Alert.success(ctrl.selectedUser.username + ' has been unbanned');
       ctrl.closeConfirmUnban();
       ctrl.pullPage();
       $timeout(function() { // wait for modal to close
@@ -210,6 +215,12 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
           break;
         }
       }
+      Alert.success('Note successfully updated');
+    })
+    .catch(function(err) {
+      note.note = note.noteCopy;
+      delete note.noteCopy;
+      Alert.error('Error: ' + err.data.message);
     });
   };
 
@@ -227,6 +238,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
       ctrl.submitBtnLabel = 'Add Note';
       ctrl.noteSubmitted = false;
       ctrl.reportNote = null;
+      Alert.success('Note successfully created');
     });
   };
 
@@ -285,6 +297,7 @@ module.exports = ['$rootScope', '$scope', '$location', '$timeout', '$anchorScrol
     ctrl.queryParams.filter = newFilter;
     delete ctrl.queryParams.reportId;
     delete ctrl.queryParams.search;
+    delete ctrl.queryParams.page;
     $location.search(ctrl.queryParams);
     ctrl.reportId = null;
     ctrl.previewPost = null;

--- a/app/admin/moderation/posts.html
+++ b/app/admin/moderation/posts.html
@@ -11,7 +11,15 @@
     <input type="radio" class="hide-radio" name="table-filter" value="2" id="posts-filter-2" ng-model="ModerationCtrl.tableFilter" ng-click="ModerationCtrl.setFilter('Reviewed')" />
     <label for="posts-filter-2">Reviewed</label>
   </div>
-  <div class="small-12 medium-3 columns">&nbsp;</div>
+  <div class="small-6 medium-1 columns radio-toolbar">
+    <input type="radio" class="hide-radio" name="table-filter" value="3" id="posts-filter-3" ng-model="ModerationCtrl.tableFilter" ng-click="ModerationCtrl.setFilter('Ignored')" />
+    <label for="posts-filter-3">Ignored</label>
+  </div>
+  <div class="small-6 medium-1 columns radio-toolbar">
+    <input type="radio" class="hide-radio" name="table-filter" value="4" id="posts-filter-4" ng-model="ModerationCtrl.tableFilter" ng-click="ModerationCtrl.setFilter('Bad Report')" />
+    <label for="posts-filter-4">Bad Report</label>
+  </div>
+  <div class="small-12 medium-1 columns">&nbsp;</div>
   <div class="small-12 medium-6 columns">
     <div class="nested-input-container">
       <a ng-if="ModerationCtrl.search" ng-click="ModerationCtrl.clearSearch()" class="nested-clear-btn fa fa-times"></a>
@@ -21,7 +29,10 @@
   </div>
   <div class="admin-table-fix"></div>
 </div>
-<div class="row full-width">
+<div class="row full-width" align="center" ng-if="!ModerationCtrl.search && ModerationCtrl.count < 1">
+  <h4>No Post Reports to display in <strong>{{ModerationCtrl.filter ? ModerationCtrl.filter : 'All'}}</strong></h4>
+</div>
+<div class="row full-width" ng-if="ModerationCtrl.count > 0 || ModerationCtrl.search">
   <div ng-if="ModerationCtrl.search">
     Displaying {{ModerationCtrl.count | number}} search result(s) for "<strong>{{ModerationCtrl.search}}</strong>" in <strong>{{ModerationCtrl.filter ? ModerationCtrl.filter : 'All'}}</strong>:<br /><br />
   </div>

--- a/app/admin/moderation/users.controller.js
+++ b/app/admin/moderation/users.controller.js
@@ -1,4 +1,5 @@
-module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$anchorScroll', 'Session', 'AdminReports', 'AdminUsers', 'User', 'userReports', 'reportCount', 'page', 'limit', 'field', 'desc', 'filter', 'search', 'reportId', function($rootScope, $scope, $state, $location, $timeout, $anchorScroll, Session, AdminReports, AdminUsers, User, userReports, reportCount, page, limit, field, desc, filter, search, reportId) {
+module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$anchorScroll',
+'Alert', 'Session', 'AdminReports', 'AdminUsers', 'User', 'userReports', 'reportCount', 'page', 'limit', 'field', 'desc', 'filter', 'search', 'reportId', function($rootScope, $scope, $state, $location, $timeout, $anchorScroll, Alert, Session, AdminReports, AdminUsers, User, userReports, reportCount, page, limit, field, desc, filter, search, reportId) {
   var ctrl = this;
   this.parent = $scope.$parent;
   this.parent.tab = 'users';
@@ -9,6 +10,8 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
   this.tableFilter = 0;
   if (filter === 'Pending') { this.tableFilter = 1; }
   else if (filter === 'Reviewed') { this.tableFilter = 2; }
+  else if (filter === 'Ignored') { this.tableFilter = 3; }
+  else if (filter === 'Bad Report') { this.tableFilter = 4; }
 
   // Search Vars
   this.search = search;
@@ -109,6 +112,7 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
         ctrl.previewReport.status = updatedReport.status;
         ctrl.previewReport.updated_at = updatedReport.updated_at;
       }
+      Alert.success('Report status has been set to ' + updatedReport.status);
       $timeout(function() { ctrl.closeSetStatus(); });
       return;
     })
@@ -164,6 +168,7 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
     };
     AdminUsers.ban(params).$promise
     .then(function() {
+      Alert.success(ctrl.selectedUser.username + ' has been banned');
       ctrl.closeConfirmBan();
       ctrl.pullPage();
       $timeout(function() { // wait for modal to close
@@ -192,6 +197,7 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
     };
     AdminUsers.unban(params).$promise
     .then(function() {
+      Alert.success(ctrl.selectedUser.username + ' has been unbanned');
       ctrl.closeConfirmUnban();
       ctrl.pullPage();
       $timeout(function() { // wait for modal to close
@@ -211,6 +217,12 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
           break;
         }
       }
+      Alert.success('Note successfully updated');
+    })
+    .catch(function(err) {
+      note.note = note.noteCopy;
+      delete note.noteCopy;
+      Alert.error('Error: ' + err.data.message);
     });
   };
 
@@ -228,6 +240,7 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
       ctrl.submitBtnLabel = 'Add Note';
       ctrl.noteSubmitted = false;
       ctrl.reportNote = null;
+      Alert.success('Note successfully created');
     });
   };
 
@@ -280,6 +293,7 @@ module.exports = ['$rootScope', '$scope', '$state', '$location', '$timeout', '$a
     ctrl.queryParams.filter = newFilter;
     delete ctrl.queryParams.reportId;
     delete ctrl.queryParams.search;
+    delete ctrl.queryParams.page;
     $location.search(ctrl.queryParams);
     ctrl.reportId = null;
     ctrl.selectedUsername = null;

--- a/app/admin/moderation/users.html
+++ b/app/admin/moderation/users.html
@@ -11,7 +11,15 @@
     <input type="radio" class="hide-radio" name="table-filter" value="2" id="users-filter-2" ng-model="ModerationCtrl.tableFilter" ng-click="ModerationCtrl.setFilter('Reviewed')" />
     <label for="users-filter-2">Reviewed</label>
   </div>
-  <div class="small-12 medium-3 columns">&nbsp;</div>
+  <div class="small-6 medium-1 columns radio-toolbar">
+    <input type="radio" class="hide-radio" name="table-filter" value="3" id="posts-filter-3" ng-model="ModerationCtrl.tableFilter" ng-click="ModerationCtrl.setFilter('Ignored')" />
+    <label for="posts-filter-3">Ignored</label>
+  </div>
+  <div class="small-6 medium-1 columns radio-toolbar">
+    <input type="radio" class="hide-radio" name="table-filter" value="4" id="posts-filter-4" ng-model="ModerationCtrl.tableFilter" ng-click="ModerationCtrl.setFilter('Bad Report')" />
+    <label for="posts-filter-4">Bad Report</label>
+  </div>
+  <div class="small-12 medium-1 columns">&nbsp;</div>
   <div class="small-12 medium-6 columns">
     <div class="nested-input-container">
       <a ng-if="ModerationCtrl.search" ng-click="ModerationCtrl.clearSearch()" class="nested-clear-btn fa fa-times"></a>
@@ -21,7 +29,10 @@
   </div>
   <div class="admin-table-fix"></div>
 </div>
-<div class="row full-width">
+<div class="row full-width" align="center" ng-if="!ModerationCtrl.search && ModerationCtrl.count < 1">
+  <h4>No User Reports to display in <strong>{{ModerationCtrl.filter ? ModerationCtrl.filter : 'All'}}</strong></h4>
+</div>
+<div class="row full-width" ng-if="ModerationCtrl.count > 0 || ModerationCtrl.search">
   <div ng-if="ModerationCtrl.search">
     Displaying {{ModerationCtrl.count | number}} search result(s) for "<strong>{{ModerationCtrl.search}}</strong>" in <strong>{{ModerationCtrl.filter ? ModerationCtrl.filter : 'All'}}</strong>:<br /><br />
   </div>

--- a/app/components/category_editor/category-editor.directive.js
+++ b/app/components/category_editor/category-editor.directive.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var _ = require('lodash');
 
 module.exports = ['$state', function($state) {
   return {
@@ -149,7 +148,7 @@ module.exports = ['$state', function($state) {
         })
         .then(function() {
           console.log('Done Saving!');
-          return $state.go($state.$current, null, { reload: true });
+          return $state.go($state.$current, { saved: true }, { reload: true });
         });
       };
 

--- a/app/config.js
+++ b/app/config.js
@@ -401,7 +401,7 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
       resolve: { userAccess: adminCheck }
     })
     .state('admin-management.boards', {
-      url: '/boards',
+      url: '/boards?saved',
       views: {
         'data@admin-management': {
           controller: 'CategoriesCtrl',

--- a/server/routes/admin/reports/config.js
+++ b/server/routes/admin/reports/config.js
@@ -1,6 +1,7 @@
 var Joi = require('joi');
 var path = require('path');
 var Boom = require('boom');
+var pre = require(path.normalize(__dirname + '/pre'));
 var commonAdminPre = require(path.normalize(__dirname + '/../../common')).auth;
 var db = require(path.normalize(__dirname + '/../../../../db'));
 
@@ -192,7 +193,10 @@ exports.updatePostReport = {
   */
 exports.updateUserReportNote = {
   auth: { mode: 'required', strategy: 'jwt' },
-  pre: [ { method: commonAdminPre.modCheck || commonAdminPre.adminCheck } ],
+  pre: [
+    { method: commonAdminPre.modCheck || commonAdminPre.adminCheck },
+    { method: pre.canUpdateUserReportNote }
+  ],
   validate: {
     payload: {
       id: Joi.alternatives().try(Joi.string(), Joi.number()).required(),
@@ -231,7 +235,10 @@ exports.updateUserReportNote = {
   */
 exports.updatePostReportNote = {
   auth: { mode: 'required', strategy: 'jwt' },
-  pre: [ { method: commonAdminPre.modCheck || commonAdminPre.adminCheck } ],
+  pre: [
+    { method: commonAdminPre.modCheck || commonAdminPre.adminCheck },
+    { method: pre.canUpdatePostReportNote }
+  ],
   validate: {
     payload: {
       id: Joi.alternatives().try(Joi.string(), Joi.number()).required(),

--- a/server/routes/admin/reports/pre.js
+++ b/server/routes/admin/reports/pre.js
@@ -1,0 +1,28 @@
+var path = require('path');
+var Boom = require('boom');
+var db = require(path.normalize(__dirname + '/../../../../db'));
+
+module.exports = {
+  canUpdateUserReportNote: function(request, reply) {
+    var userId = request.auth.credentials.id;
+    var noteId = request.payload.id;
+    db.reports.findUserReportNote(noteId)
+    .then(function(note) {
+      var noteUserId = note.user_id;
+      if (noteUserId === userId) { return reply(); }
+      else { return reply(Boom.unauthorized('Only the author of this user report note can update it')); }
+    })
+    .catch(function(err) { return reply(Boom.badRequest(err)); });
+  },
+  canUpdatePostReportNote: function(request, reply) {
+    var userId = request.auth.credentials.id;
+    var noteId = request.payload.id;
+    db.reports.findPostReportNote(noteId)
+    .then(function(note) {
+      var noteUserId = note.user_id;
+      if (noteUserId === userId) { return reply(); }
+      else { return reply(Boom.unauthorized('Only the author of this post report note can update it')); }
+    })
+    .catch(function(err) { return reply(Boom.badRequest(err)); });
+  }
+};

--- a/server/routes/common.js
+++ b/server/routes/common.js
@@ -139,7 +139,7 @@ function isMod(authenticated, username) {
       });
       return isMod;
     })
-    .catch(function() { return isMod });
+    .catch(function() { return isMod; });
   }
 
   return promise;


### PR DESCRIPTION
* Added alerts for all actions in admin panel views. This includes
  banning, unbanning, saving categories, setting report statuses,
  editing users profile, adding/removing moderators and admins,
  saving board categories and adding/updating report notes.

* Displaying message indicating that there are no rows instead of
  displaying empty tables for Users, Moderators, Administrators and
  reporting pages.

* Added addition filters which were missing from the ui for ignored
  and bad reports on the posts and users moderation pages.

* Added pre method to check that only the author can update
  moderation report notes.

* NOTE: There is a hack in place to get alert to display when boards
  and categories are saved. In the future we should find a better
  way to acheive this. I didn't feel it was worth spending too much
  time on considering that we might change the ui for updating/saving
  boards and categories.

Test Procedure:

* Log in as an administrator and visit the administration panel

* Test that any view that allows for taking action has a confirmation alert. Actions include: banning/unbanning, editing user profile, saving boards, adding moderators/administrators, setting report statuses, adding/updating report notes or adding a moderator or admin who is already an admin/moderator.

* Ensure that new filters for "Ignored" and "Bad Report" are present in both moderation views for users/posts. Test these filters by marking reports "Ignored" and "Bad Reports"

* Test that views in admin panel with tables and no records no longer display an empty table, but instead a message indicating that there are not records to display.

* To test pre methods on updating moderation notes, you can invert lines 12 and 23 in the admin/reports/pre.js file from:
```js
if (noteUserId === userId)
```
to this:
```js
if (noteUserId !== userId)
```
then attempt to update one of your existing notes on a post and user report.