### PR TITLE
Private Messages

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -34,6 +34,7 @@ app.controller('ProfileCtrl',       require('./user/profile.controller.js'));
 app.controller('ProfilePostsCtrl',  require('./user/posts.controller.js'));
 app.controller('ResetCtrl',         require('./user/reset.controller.js'));
 app.controller('ConfirmCtrl',       require('./user/confirm.controller.js'));
+app.controller('MessagesCtrl',      require('./messages/messages.controller.js'));
 
 // Register Admin Page Controllers
 app.controller('GeneralSettingsCtrl', require('./admin/settings/general.controller.js'));
@@ -64,6 +65,7 @@ app.directive('postProcessing',         require('./components/post-processing/po
 app.directive('imageUploader',          require('./components/image_uploader/image_uploader.directive.js'));
 app.directive('alert',                  require('./components/alert/alert.directive.js'));
 app.directive('autocompleteUsername',   require('./components/autocomplete_username/autocomplete-username.directive.js'));
+app.directive('autocompleteUserId',   require('./components/autocomplete_user_id/autocomplete-user-id.directive.js'));
 
 // Set Angular Configs
 app.config(require('./config'))

--- a/app/components/autocomplete_user_id/autocomplete-user-id.directive.js
+++ b/app/components/autocomplete_user_id/autocomplete-user-id.directive.js
@@ -1,0 +1,38 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = ['Messages', function(Messages) {
+  return {
+    restrict: 'E',
+    template: fs.readFileSync(path.normalize(__dirname + '/autocomplete-user-id.html')),
+    scope: {
+      userId: '=',
+      username: '=',
+      inputPlaceholder: '@',
+    },
+    controller: function($scope) {
+      $scope.searchResults = [];
+      $scope.usernameIsValid = false;
+
+      $scope.$watch('username', function() {
+        $scope.userId = '';
+        $scope.usernameIsValid = false;
+        if (!$scope.username || !$scope.username.length) { return; }
+        $scope.searchResults = [];
+        Messages.findUser({ username: $scope.username }).$promise
+        .then(function(results) {
+          $scope.searchResults = results;
+          // ignore casing
+          for (var i = 0; i < results.length; i++) {
+            var lowerCasedUsername = results[i].username.toLowerCase();
+            if (lowerCasedUsername === $scope.username.toLowerCase()) {
+              $scope.userId = results[i].id;
+              $scope.usernameIsValid = true;
+              break;
+            }
+          }
+        });
+      });
+    }
+  };
+}];

--- a/app/components/autocomplete_user_id/autocomplete-user-id.html
+++ b/app/components/autocomplete_user_id/autocomplete-user-id.html
@@ -1,0 +1,6 @@
+<div class="nested-input-container">
+  <input class="nested-input" ng-class="{ 'valid-username': usernameIsValid }" ng-model="username" ng-model-options="{ debounce: 300 }" type="text" list="usernames" id="user-search" placeholder="{{inputPlaceholder}}" style="padding-right: 0px"/>
+  <datalist id="usernames">
+    <option ng-repeat="result in searchResults track by result.id" value="{{result.username}}" ng-click="selectUser(username)">
+  </datalist>
+</div>

--- a/app/config.js
+++ b/app/config.js
@@ -730,6 +730,25 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
       }
     });
 
+    $stateProvider.state('messages', {
+      url: '/messages',
+      parent: 'public-layout',
+      views: {
+        'content': {
+          controller: 'MessagesCtrl',
+          controllerAs: 'MessagesCtrl',
+          template: fs.readFileSync(__dirname + '/messages/messages.html')
+        }
+      },
+      resolve: {
+        $title: function() { return 'Private Messages'; },
+        pageData: ['Messages', function(Messages) {
+          return Messages.latest().$promise
+          .then(function(messages) { return messages; });
+        }]
+      }
+    });
+
     $stateProvider.state('404', {
       views: {
         'body': {

--- a/app/layout/header.html
+++ b/app/layout/header.html
@@ -54,6 +54,9 @@
                   <a ui-sref="profile({ username: HeaderCtrl.currentUser.username })" ui-sref-opts="{ reload: true }">Profile</a>
                 </li>
                 <li>
+                  <a ui-sref="messages" ui-sref-opts="{ reload: true }">Messages</a>
+                </li>
+                <li>
                   <a ng-href="#" ng-click="HeaderCtrl.logout()">Logout</a>
                 </li>
               </ul>
@@ -77,6 +80,9 @@
             </li>
             <li>
               <a ui-sref="profile({ username: HeaderCtrl.currentUser.username })" ui-sref-opts="{ reload: true }">Profile</a>
+            </li>
+            <li>
+              <a ui-sref="messages" ui-sref-opts="{ reload: true }">Messages</a>
             </li>
             <li>
               <a ng-href="#" ng-click="HeaderCtrl.logout()">Logout</a>

--- a/app/messages/messages.controller.js
+++ b/app/messages/messages.controller.js
@@ -1,0 +1,220 @@
+var bbcodeParser = require('epochtalk-bbcode-parser');
+
+module.exports = [
+  '$scope', '$rootScope', '$timeout', '$window', '$location', '$anchorScroll', 'Session', 'Alert', 'Messages', 'Conversations', 'pageData',
+  function($scope, $rootScope, $timeout, $window, $location, $anchorScroll, Session, Alert, Messages, Conversations, pageData) {
+    var ctrl = this;
+    this.currentUserId = Session.user.id;
+    this.recentMessages = pageData.messages;
+    this.totalMessageCount = pageData.total_convo_count;
+    this.page = pageData.page;
+    this.limit = pageData.limit;
+    this.pageMax = Math.ceil(pageData.total_convo_count / pageData.limit);
+    this.currentConversation = {messages: []};
+    this.newConversation = {body: '', receiver_id: ''};
+    this.newMessage = {body: '', receiver_id: '', previewBody: ''};
+
+    // page exiting functions
+    var confirmMessage = 'It looks like a message is being written.';
+    var exitFunction = function() {
+      if (ctrl.newMessage.body.length) { return confirmMessage; }
+    };
+    $window.onbeforeunload = exitFunction;
+    var routeLeaveFunction = function() {
+      return $rootScope.$on('$stateChangeStart', function(e, toState, toParams, fromState, fromParams) {
+        if (toState.url === fromState.url) { return; }
+        if (ctrl.newMessage.body.length) {
+          var message = confirmMessage + ' Are you sure you want to leave?';
+          var answer = confirm(message);
+          if (!answer) { e.preventDefault(); }
+        }
+      });
+    };
+    var destroyRouteBlocker = routeLeaveFunction();
+    $scope.$on('$destroy', function() {
+      $window.onbeforeunload = undefined;
+      if (destroyRouteBlocker) { destroyRouteBlocker(); }
+    });
+
+    // Conversations
+
+    this.loadConversation = function(conversationId) {
+      Conversations.messages({id: conversationId}).$promise
+      // build out conversation information
+      .then(function(data) {
+        ctrl.currentConversation = data;
+        ctrl.currentConversation.members = {};
+        loadConversationMembers(data.messages);
+        return data;
+      })
+      // build out reply information
+      .then(function(data) {
+        ctrl.newMessage = {};
+        ctrl.newMessage.conversation_id = data.id;
+        ctrl.newMessage.sender_id = Session.user.id;
+        ctrl.newMessage.sender_username = Session.user.username;
+        var lastMessage = data.messages[data.messages.length - 1];
+        var lastReceiverId = lastMessage.receiver_id;
+        var lastSenderId = lastMessage.sender_id;
+        if (Session.user.id === lastSenderId) {
+          ctrl.newMessage.receiver_id = lastReceiverId;
+          ctrl.newMessage.receiver_username = lastMessage.receiver_username;
+        }
+        else {
+          ctrl.newMessage.receiver_id = lastSenderId;
+          ctrl.newMessage.receiver_username = lastMessage.sender_username;
+        }
+      })
+      // scroll last message into view
+      .then(function() {
+        var messageLength = ctrl.currentConversation.messages.length;
+        var lastMessage = ctrl.currentConversation.messages[messageLength - 1];
+        $location.hash(lastMessage.id);
+        $anchorScroll();
+      });
+    };
+
+    this.loadMoreMessages = function() {
+      var query = {
+        id: ctrl.currentConversation.id,
+        timestamp: ctrl.currentConversation.last_message_timestamp,
+        messageId: ctrl.currentConversation.last_message_id
+      };
+      Conversations.messages(query).$promise
+      // build out conversation information
+      .then(function(data) {
+        ctrl.currentConversation.messages = data.messages.concat(ctrl.currentConversation.messages);
+        ctrl.currentConversation.last_message_id = data.last_message_id;
+        ctrl.currentConversation.last_message_timestamp = data.last_message_timestamp;
+        ctrl.currentConversation.hasNext = data.hasNext;
+        loadConversationMembers(data.messages);
+        return data;
+      })
+      // scroll to last message
+      .then(function(data) {
+        var messageLength = data.messages.length;
+        var lastMessage = data.messages[messageLength - 1];
+        $location.hash(lastMessage.id);
+        $anchorScroll();
+      });
+    };
+
+    this.hasMoreMessages = function() { return ctrl.currentConversation.hasNext; };
+
+    function loadConversationMembers(messages) {
+      messages.map(function(message) {
+        if (message.sender_id !== Session.user.id) {
+          ctrl.currentConversation.members[message.sender_id] = message.sender_username;
+        }
+
+        if (message.receiver_id !== Session.user.id) {
+          ctrl.currentConversation.members[message.receiver_id] = message.receiver_username;
+        }
+
+        message.copied.map(function(copied) {
+          if (copied.id !== Session.user.id) {
+            ctrl.currentConversation.members[copied.id] = copied.username;
+          }
+        });
+      });
+    }
+
+    this.showConvoModal = false;
+    this.closeConvoModal = function() {
+      $timeout(function() {
+        ctrl.newConversation = {};
+        ctrl.showConvoModal = false;
+      });
+    };
+    this.openConvoModal = function(index) { ctrl.showConvoModal = true; };
+    this.createConversation = function() {
+      // create a new conversation id to put this message under
+      var newMessage = {
+        receiver_id: ctrl.newConversation.receiver_id,
+        body: ctrl.newConversation.body,
+      };
+
+      Conversations.save(newMessage).$promise
+      .then(function(savedMessage) {
+        // open conversation
+        ctrl.loadConversation(savedMessage.conversation_id);
+
+        // Add message to list
+        savedMessage.receiver_username = ctrl.newConversation.receiver_username;
+        savedMessage.sender_username = Session.user.username;
+        ctrl.recentMessages.unshift(savedMessage);
+        Alert.success('New Conversation Started!');
+      })
+      .catch(function(err) { Alert.error('Failed to create conversation'); })
+      .finally(function() { ctrl.showConvoModal = false; });
+    };
+
+    // Messages
+
+    this.loadRecentMessages = function(page, limit) {
+      if (page <= 0 || page > ctrl.pageMax) { return; }
+      page = page || 1;
+      limit = limit || 15;
+      Messages.latest({ page: page, limit: limit}).$promise
+      .then(function(data) {
+        ctrl.recentMessages = data.messages;
+        ctrl.totalConvoCount = data.total_convo_count;
+        ctrl.limit = data.limit;
+        ctrl.page = data.page;
+        ctrl.pageMax = Math.ceil(data.total_convo_count / data.limit);
+      });
+    };
+
+    $scope.$watch(function() { return ctrl.newMessage.body; }, function(body) {
+      if (body) {
+        // BBCode Parsing
+        var rawText = body;
+        rawText = rawText.replace(/(?:<|&lt;)/g, '&#60;'); // prevent html
+        rawText = rawText.replace(/(?:>|&gt;)/g, '&#62;');
+        var processed = bbcodeParser.process({text: rawText}).html;
+        // re-bind to scope
+        ctrl.newMessage.previewBody = processed;
+      }
+    });
+
+    this.saveMessage = function() {
+      Messages.save(ctrl.newMessage).$promise
+      .then(function(message) {
+        message.receiver_username = ctrl.newMessage.receiver_username;
+        message.sender_username = ctrl.newMessage.sender_username;
+        ctrl.currentConversation.messages.push(message);
+      })
+      .then(ctrl.loadRecentMessages)
+      .then(function() {
+        ctrl.newMessage.body = '';
+        ctrl.newMessage.previewBody = '';
+      })
+      .catch(function(err) { Alert.error('Message could not be sent'); });
+    };
+
+    this.deleteMessageId = '';
+    this.showDeleteModal = false;
+    this.closeDeleteModal = function() {
+      $timeout(function() { ctrl.showDeleteModal = false; });
+    };
+    this.openDeleteModal = function(messageId) {
+      ctrl.deleteMessageId = messageId;
+      ctrl.showDeleteModal = true;
+    };
+    this.deleteMessage = function() {
+      Messages.delete({id: ctrl.deleteMessageId}).$promise
+      .then(function() {
+        var messages = [];
+        ctrl.currentConversation.messages.forEach(function(message) {
+          if (message.id === ctrl.deleteMessageId) { return; }
+          else { messages.push(message); }
+        });
+        ctrl.currentConversation.messages = messages;
+        ctrl.loadRecentMessages();
+      })
+      .catch(function(err) {Alert.error('Failed to delete message'); })
+      .finally(function() { ctrl.showDeleteModal = false; });
+    };
+
+  }
+];

--- a/app/messages/messages.controller.js
+++ b/app/messages/messages.controller.js
@@ -21,7 +21,7 @@ module.exports = [
     };
     $window.onbeforeunload = exitFunction;
     var routeLeaveFunction = function() {
-      return $rootScope.$on('$stateChangeStart', function(e, toState, toParams, fromState, fromParams) {
+      return $rootScope.$on('$stateChangeStart', function(e, toState, toParams, fromState) {
         if (toState.url === fromState.url) { return; }
         if (ctrl.newMessage.body.length) {
           var message = confirmMessage + ' Are you sure you want to leave?';
@@ -49,7 +49,7 @@ module.exports = [
       })
       // build out reply information
       .then(function(data) {
-        ctrl.newMessage = {};
+        ctrl.newMessage = { body: '', previewBody: '' };
         ctrl.newMessage.conversation_id = data.id;
         ctrl.newMessage.sender_id = Session.user.id;
         ctrl.newMessage.sender_username = Session.user.username;
@@ -126,7 +126,7 @@ module.exports = [
         ctrl.showConvoModal = false;
       });
     };
-    this.openConvoModal = function(index) { ctrl.showConvoModal = true; };
+    this.openConvoModal = function() { ctrl.showConvoModal = true; };
     this.createConversation = function() {
       // create a new conversation id to put this message under
       var newMessage = {
@@ -142,10 +142,10 @@ module.exports = [
         // Add message to list
         savedMessage.receiver_username = ctrl.newConversation.receiver_username;
         savedMessage.sender_username = Session.user.username;
-        ctrl.recentMessages.unshift(savedMessage);
         Alert.success('New Conversation Started!');
+        ctrl.loadRecentMessages();
       })
-      .catch(function(err) { Alert.error('Failed to create conversation'); })
+      .catch(function() { Alert.error('Failed to create conversation'); })
       .finally(function() { ctrl.showConvoModal = false; });
     };
 
@@ -189,7 +189,7 @@ module.exports = [
         ctrl.newMessage.body = '';
         ctrl.newMessage.previewBody = '';
       })
-      .catch(function(err) { Alert.error('Message could not be sent'); });
+      .catch(function() { Alert.error('Message could not be sent'); });
     };
 
     this.deleteMessageId = '';
@@ -212,7 +212,7 @@ module.exports = [
         ctrl.currentConversation.messages = messages;
         ctrl.loadRecentMessages();
       })
-      .catch(function(err) {Alert.error('Failed to delete message'); })
+      .catch(function() {Alert.error('Failed to delete message'); })
       .finally(function() { ctrl.showDeleteModal = false; });
     };
 

--- a/app/messages/messages.html
+++ b/app/messages/messages.html
@@ -13,7 +13,7 @@
       </div>
       <div style="font-weight: bold; border-bottom: 1px solid #ccc; background-color: #eee; height: 3rem; text-align: center;">
         <button class="small-4 columns" ng-click="MessagesCtrl.loadRecentMessages(MessagesCtrl.page - 1)" ng-disabled="MessagesCtrl.page === 1" style="height: 100%;"><</button>
-        <div class="small-4 columns" style="padding-top: 0.75rem;">{{ MessagesCtrl.currentPage }}</div>
+        <div class="small-4 columns" style="padding-top: 0.75rem;">{{ MessagesCtrl.page }}</div>
         <button class="small-4 columns" ng-click="MessagesCtrl.loadRecentMessages(MessagesCtrl.page + 1)" ng-disabled="MessagesCtrl.page === MessagesCtrl.pageMax" style="height: 100%;">></button>
       </div>
     </div>

--- a/app/messages/messages.html
+++ b/app/messages/messages.html
@@ -1,0 +1,108 @@
+<!-- Page Title -->
+<div class="row" style="padding-top: 20px;">
+  <!-- Recent Conversations -->
+  <div class="small-3 columns" style="min-height: 600px;">
+    <div style="border: 1px solid #ccc; border-bottom: 0;">
+      <div id="recentMessagesHeader" style="font-weight: bold; border-bottom: 1px solid #ccc; background-color: #eee; height: 3rem;">
+        <div class="small-9 columns" ng-click="MessagesCtrl.loadRecentMessages();" style="margin-top: 0.75rem; cursor: pointer;">Inbox</div>
+        <div class="small-3 columns" ng-click="MessagesCtrl.showConvoModal = true" style="cursor: pointer; padding-top: 0.75rem; border-left: 1px solid #ccc; height: 100%; text-align: center;"> + </div>
+      </div>
+      <div ng-repeat="message in MessagesCtrl.recentMessages track by message.id" style="padding: 0.25rem; font-size: 0.8rem; border-bottom: 1px solid #ccc; white-space: nowrap; text-overflow: ellipsis; height: 3rem; cursor: pointer; overflow: hidden;" ng-click="MessagesCtrl.loadConversation(message.conversation_id)">
+        To: <strong>{{ message.receiver_username }}</strong><br>
+        <em>{{ message.body }}</em>
+      </div>
+      <div style="font-weight: bold; border-bottom: 1px solid #ccc; background-color: #eee; height: 3rem; text-align: center;">
+        <button class="small-4 columns" ng-click="MessagesCtrl.loadRecentMessages(MessagesCtrl.page - 1)" ng-disabled="MessagesCtrl.page === 1" style="height: 100%;"><</button>
+        <div class="small-4 columns" style="padding-top: 0.75rem;">{{ MessagesCtrl.currentPage }}</div>
+        <button class="small-4 columns" ng-click="MessagesCtrl.loadRecentMessages(MessagesCtrl.page + 1)" ng-disabled="MessagesCtrl.page === MessagesCtrl.pageMax" style="height: 100%;">></button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Current Conversation -->
+  <div class="small-9 columns" style="min-height: 600px;">
+    <!-- load more message -->
+    <button class="button expand" ng-if="MessagesCtrl.hasMoreMessages()" ng-click="MessagesCtrl.loadMoreMessages()">
+      Load More Messages
+    </button>
+
+    <!-- Conversation Messages -->
+    <div id="{{message.id}}" ng-repeat="message in MessagesCtrl.currentConversation.messages track by message.id" style="padding: 1rem; border: 1px solid #ccc; border-radius: 10px; margin-bottom: 1rem;">
+      <strong>{{ message.sender_username}}</strong>
+      <div ng-if="message.sender_id === MessagesCtrl.currentUserId" style="float: right;">
+        <a href="#" class="css-tooltip" ng-click="MessagesCtrl.openDeleteModal(message.id)" data-css-tooltip="Delete">
+          <i class="icon-epoch-unverified"></i>
+        </a>
+      </div>
+      <br>
+      <em style="font-size: smaller">{{ message.created_at | humanDate }}</em><br />
+      <div post-processing="message.body" style-fix="true">{{ message.body }}</div>
+    </div>
+    <div ng-if="MessagesCtrl.currentConversation.messages.length < 1">
+      <div style="margin: 50px auto; width: 200px;">
+        No Conversation selected
+      </div>
+    </div>
+
+    <!-- New Message -->
+    <div ng-if="MessagesCtrl.currentConversation.messages.length > 0" style="width: 100%; border: 1px solid #ccc; padding: 1rem;">
+      <!-- Messages Receiver -->
+      <label>Receiver:
+        <autocomplete-user-id user-id="MessagesCtrl.newMessage.receiver_id" username="MessagesCtrl.newMessage.receiver_username" ></autocomplete-user-id>
+      </label>
+      <!-- Message Body and Send button-->
+      <label>Message:
+        <textarea ng-model="MessagesCtrl.newMessage.body" ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 } }"
+         style="height: 5rem; margin: 0; resize: none;"></textarea>
+        <div ng-show="MessagesCtrl.newMessage.preview" post-processing="MessagesCtrl.newMessage.previewBody" style="height: 5rem; margin:0; resize: none; background-color: #eee;"></div>
+      </label>
+      <button ng-click="MessagesCtrl.newMessage.preview = !MessagesCtrl.newMessage.preview">Toggle Preview</button>
+      <button class="button expand" ng-click="MessagesCtrl.saveMessage()" ng-disabled="!MessagesCtrl.newMessage.body || !MessagesCtrl.newMessage.receiver_id">Send</button>
+    </div>
+  </div>
+</div>
+
+
+<!-- Create New Conversation Modal -->
+<modal class="medium" show="MessagesCtrl.showConvoModal" on-close="MessagesCtrl.closeConvoModal()">
+  <form name="$parent.form" class="css-form" novalidate>
+    <!-- Select User -->
+    <label>To:
+      <autocomplete-user-id user-id="MessagesCtrl.newConversation.receiver_id" username="MessagesCtrl.newConversation.receiver_username" ></autocomplete-user-id>
+    </label>
+
+    <!-- Select copied users -->
+
+    <!-- Message Body -->
+    <label>Message:
+      <textarea type="text" rows="10" ng-model="MessagesCtrl.newConversation.body"></textarea>
+    </label>
+
+    <!-- Save Button -->
+    <div class="row">
+      <button class="button expand" ng-click="MessagesCtrl.createConversation()" ng-disabled="!MessagesCtrl.newConversation.body || !MessagesCtrl.newConversation.receiver_id">
+        Start Conversation
+      </button>
+    </div>
+  </form>
+
+  <a class="close-reveal-modal">&#215;</a>
+</modal>
+
+<!-- Delete Message Modal -->
+<modal class="medium" show="MessagesCtrl.showDeleteModal" on-close="MessagesCtrl.closeDeleteModal()">
+  <form name="$parent.form" class="css-form" novalidate>
+    <center>
+      <p>Are you sure you want to permanently delete this message?</p>
+    </center>
+
+    <!-- Save Button -->
+    <div class="row">
+      <button class="button expand" ng-click="MessagesCtrl.deleteMessage()">
+        Delete Message
+      </button>
+    </div>
+  </form>
+
+  <a class="close-reveal-modal">&#215;</a>
+</modal>

--- a/app/resources/conversations.js
+++ b/app/resources/conversations.js
@@ -1,0 +1,19 @@
+'use strict';
+/* jslint node: true */
+
+module.exports = ['$resource',
+  function($resource) {
+    return $resource('/api/conversations/:id', {}, {
+      messages: {
+        method: 'GET',
+        url: '/api/conversations/:id',
+        params: {
+          id: '@id',
+          limit: '@limit',
+          timestamp: '@timestamp',
+          messageId: '@messageId'
+        }
+      }
+    });
+  }
+];

--- a/app/resources/index.js
+++ b/app/resources/index.js
@@ -8,4 +8,6 @@ angular.module('ept')
   .factory('Posts', require('./posts.js'))
   .factory('Reports', require('./reports.js'))
   .factory('Settings', require('./settings.js'))
-  .factory('User', require('./user.js'));
+  .factory('User', require('./user.js'))
+  .factory('Messages', require('./messages.js'))
+  .factory('Conversations', require('./conversations.js'));

--- a/app/resources/messages.js
+++ b/app/resources/messages.js
@@ -1,0 +1,23 @@
+'use strict';
+/* jslint node: true */
+
+module.exports = ['$resource',
+  function($resource) {
+    return $resource('/api/messages/:id', {}, {
+      latest: {
+        method: 'GET',
+        url: '/api/messages',
+        params: {
+          limit: '@limit',
+          page: '@page'
+        }
+      },
+      findUser: {
+        method: 'GET',
+        url: '/api/messages/users/:username',
+        params: { username: '@username' },
+        isArray: true
+      }
+    });
+  }
+];

--- a/app/resources/messages.js
+++ b/app/resources/messages.js
@@ -16,7 +16,8 @@ module.exports = ['$resource',
         method: 'GET',
         url: '/api/messages/users/:username',
         params: { username: '@username' },
-        isArray: true
+        isArray: true,
+        ignoreLoadingBar: true
       }
     });
   }

--- a/server/routes/conversations/config.js
+++ b/server/routes/conversations/config.js
@@ -1,0 +1,139 @@
+var Joi = require('joi');
+var path = require('path');
+var Boom = require('boom');
+var Promise = require('bluebird');
+var db = require(path.normalize(__dirname + '/../../../db'));
+var commonPre = require(path.normalize(__dirname + '/../common'));
+var messagePre = require(path.normalize(__dirname + '/../messages/pre'));
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Conversations
+  * @api {POST} /conversations Create
+  * @apiName CreateConversation
+  * @apiPermission User
+  * @apiDescription Used to create a new conversation.
+  *
+  * @apiUse ConversationObjectSuccess
+  *
+  * @apiError (Error 500) InternalServerError There was an issue creating the conversation
+  */
+exports.create = {
+  auth: { strategy: 'jwt' },
+  validate: {
+    payload: {
+      receiver_id: Joi.string().required(),
+      copied_ids: Joi.array().items(Joi.string()).default([]),
+      body: Joi.string().min(1).required()
+    }
+  },
+  pre: [
+    { method: messagePre.clean },
+    { method: messagePre.parseEncodings }
+  ],
+  handler: function(request, reply) {
+    // create the conversation in db
+    var promise = db.conversations.create()
+    .then(function(conversation) {
+      var message = request.payload;
+      message.conversation_id = conversation.id;
+      message.sender_id = request.auth.credentials.id;
+      return message;
+    })
+    .then(db.messages.create);
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Conversations
+  * @api {GET} /conversations Messages in Conversation
+  * @apiName GetRecentMessages
+  * @apiPermission User
+  * @apiDescription Used to get messages for this conversation.
+  *
+  * @apiUse ConversationObjectSuccess
+  *
+  * @apiError (Error 500) InternalServerError There was an issue getting messages for this conversation
+  */
+exports.messages = {
+  auth: { strategy: 'jwt' },
+  validate: {
+    params: { conversationId: Joi.string() },
+    query: {
+      timestamp: Joi.date(),
+      messageId: Joi.string(),
+      limit: Joi.number().integer().min(1).max(100).default(15)
+    }
+  },
+  handler: function(request, reply) {
+    var conversationId = request.params.conversationId;
+    var userId = request.auth.credentials.id;
+    var opts = {
+      timestamp: request.query.timestamp,
+      messageId: request.query.messageId,
+      limit: request.query.limit + 1 // plus for hasNext testing
+    };
+
+    // create the conversation in db
+    var promise = db.conversations.messages(conversationId, userId, opts)
+    .then(function(messages) {
+      // default return values
+      var payload = { id: request.params.conversationId };
+
+      // handle message hasNext and possible extra message
+      if (messages.length === opts.limit) {
+        messages.shift();
+        payload.messages = messages;
+        payload.hasNext = true;
+      }
+      else {
+        payload.messages = messages;
+        payload.hasNext = false;
+      }
+
+      // last message values if there are any messages
+      if (messages.length) {
+        payload.last_message_timestamp = messages[0].created_at;
+        payload.last_message_id = messages[0].id;
+      }
+
+      return payload;
+    });
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Conversations
+  * @api {DELETE} /conversations/:id Delete
+  * @apiName DeleteConversation
+  * @apiPermission User (Convesation's Author) or Admin
+  * @apiDescription Used to delete a conversation.
+  *
+  * @apiParam {string} id The Id of the conversation to delete
+  *
+  * @apiUse ConversationObjectSuccess
+  *
+  * @apiError (Error 400) BadRequest Conversation Already Deleted
+  * @apiError (Error 500) InternalServerError There was an issue deleting the conversation
+  */
+exports.delete = {
+  auth: { strategy: 'jwt' },
+  validate: { params: { id: Joi.string().required() } },
+  pre: [ { method: commonPre.auth.adminCheck } ], //handle permissions
+  // delete by admin only
+  handler: function(request, reply) {
+    var promise = db.conversations.delete(request.params.id)
+    .error(function(err) { return Boom.badRequest(err.message); });
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiDefine ConversationObjectSuccess
+  * @apiSuccess {string} id The unique id of the conversation
+  * @apiSuccess {timestamp} created_at Timestamp of when the conversation was created
+  */

--- a/server/routes/conversations/index.js
+++ b/server/routes/conversations/index.js
@@ -1,0 +1,9 @@
+var path = require('path');
+var conversations = require(path.normalize(__dirname + '/config'));
+
+// Export Routes/Pre
+module.exports = [
+  { method: 'POST', path: '/conversations', config: conversations.create },
+  { method: 'GET', path: '/conversations/{conversationId}', config: conversations.messages },
+  { method: 'DELETE', path: '/conversations/{id}', config: conversations.delete }
+];

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -16,9 +16,11 @@ var settings = require(path.normalize(__dirname + '/settings'));
 var adminSettings = require(path.normalize(__dirname + '/admin/settings'));
 var adminUsers = require(path.normalize(__dirname + '/admin/users'));
 var adminReports = require(path.normalize(__dirname + '/admin/reports'));
+var conversations = require(path.normalize(__dirname + '/conversations'));
+var messages = require(path.normalize(__dirname + '/messages'));
 
 function buildEndpoints() {
-  return [].concat(breadcrumbs, categories, boards, threads, posts, users, auth, reports, settings);
+  return [].concat(breadcrumbs, categories, boards, threads, posts, users, auth, reports, settings, conversations, messages);
 }
 
 function buildAdminEndpoints() {

--- a/server/routes/messages/config.js
+++ b/server/routes/messages/config.js
@@ -1,0 +1,147 @@
+var Joi = require('joi');
+var path = require('path');
+var Boom = require('boom');
+var Promise = require('bluebird');
+var db = require(path.normalize(__dirname + '/../../../db'));
+var pre = require(path.normalize(__dirname + '/pre'));
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Messages
+  * @api {POST} /messages Create
+  * @apiName CreateMessage
+  * @apiPermission User
+  * @apiDescription Used to create a new message.
+  *
+  * @apiUse MessageObjectSuccess
+  *
+  * @apiError (Error 500) InternalServerError There was an issue creating the message
+  */
+exports.create = {
+  auth: { strategy: 'jwt' },
+  validate: {
+    payload: {
+      conversation_id: Joi.string().required(),
+      receiver_id: Joi.string().required(),
+      copied_ids: Joi.array().items(Joi.string()).default([]),
+      body: Joi.string().min(1).required()
+    }
+  },
+  pre: [
+    { method: pre.canCreate },
+    { method: pre.clean },
+    { method: pre.parseEncodings }
+  ],
+  handler: function(request, reply) {
+    var message = request.payload;
+    message.sender_id = request.auth.credentials.id;
+
+    // create the message in db
+    var promise = db.messages.create(message);
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Messages
+  * @api {GET} /messages Get Recent Messages
+  * @apiName LatestMessages
+  * @apiPermission User
+  * @apiDescription Get the latest messages for this user.
+  *
+  * @apiUse MessageObjectSuccess
+  *
+  * @apiError (Error 500) InternalServerError There was an issue getting the messages
+  */
+exports.latest = {
+  auth: { strategy: 'jwt' },
+  validate: {
+    query: {
+      page: Joi.number().integer().default(1),
+      limit: Joi.number().integer().min(1).max(100).default(15)
+    }
+  },
+  handler: function(request, reply) {
+    var userId = request.auth.credentials.id;
+    var opts = {
+      limit: request.query.limit,
+      page: request.query.page
+    };
+
+    // get latest messages for userId
+    var getMessages = db.messages.latest(userId, opts);
+    var getCount = db.messages.conversationCount(userId);
+    var promise = Promise.join(getMessages, getCount, function(messages, count) {
+      return {
+        messages: messages,
+        total_convo_count: count,
+        page: opts.page,
+        limit: opts.limit
+      };
+    });
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Messages
+  * @api {GET} /messages/users/{username} Get ID for username
+  * @apiName FindUser
+  * @apiPermission User
+  * @apiDescription Get the id for the given username
+  *
+  * @apiUse MessageObjectSuccess
+  *
+  * @apiError (Error 500) InternalServerError There was an issue getting the messages
+  */
+exports.findUser = {
+  // auth: { strategy: 'jwt' },
+  validate: { params: { username: Joi.string().required() } },
+  handler: function(request, reply) {
+    // get id for username
+    var username = request.params.username;
+    var promise = db.messages.findUser(username);
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiVersion 0.3.0
+  * @apiGroup Messages
+  * @api {DELETE} /messages/:id Delete
+  * @apiName DeleteMessage
+  * @apiPermission User (Message's Author) or Admin
+  * @apiDescription Used to delete a message.
+  *
+  * @apiParam {string} id The Id of the message to delete
+  *
+  * @apiUse MessageObjectSuccess
+  *
+  * @apiError (Error 400) BadRequest Message Already Deleted
+  * @apiError (Error 500) InternalServerError There was an issue deleting the message
+  */
+exports.delete = {
+  auth: { strategy: 'jwt' },
+  validate: { params: { id: Joi.string().required() } },
+  pre: [ { method: pre.canDelete } ], //handle permissions
+  handler: function(request, reply) {
+    // TODO: delete conversations with no more messages
+    var promise = db.messages.delete(request.params.id)
+    .error(function(err) { return Boom.badRequest(err.message); });
+    return reply(promise);
+  }
+};
+
+/**
+  * @apiDefine MessageObjectSuccess
+  * @apiSuccess {string} id The unique id of the message
+  * @apiSuccess {string} conversation_id The unique id of the conversation this message belongs to
+  * @apiSuccess {string} sender_id The unique id of the user that sent this message
+  * @apiSuccess {string} receiver_id The unique id of the user that sent this message
+  * @apiSuccess {array} copied_ids The unique id of the users that were copied on this message
+  * @apiSuccess {string} body The contents of this message
+  * @apiSuccess {boolean} viewed The flag showing if the receiver viewed this message
+  * @apiSuccess {timestamp} created_at Timestamp of when the conversation was created
+  */

--- a/server/routes/messages/index.js
+++ b/server/routes/messages/index.js
@@ -1,0 +1,10 @@
+var path = require('path');
+var messages = require(path.normalize(__dirname + '/config'));
+
+// Export Routes/Pre
+module.exports = [
+  { method: 'POST', path: '/messages', config: messages.create },
+  { method: 'GET', path: '/messages', config: messages.latest },
+  { method: 'GET', path: '/messages/users/{username}', config: messages.findUser },
+  { method: 'DELETE', path: '/messages/{id}', config: messages.delete }
+];

--- a/server/routes/messages/pre.js
+++ b/server/routes/messages/pre.js
@@ -1,0 +1,91 @@
+var path = require('path');
+var Boom = require('boom');
+var Promise = require('bluebird');
+var bbcodeParser = require('epochtalk-bbcode-parser');
+var db = require(path.normalize(__dirname + '/../../../db'));
+var commonPre = require(path.normalize(__dirname + '/../common')).auth;
+var sanitizer = require(path.normalize(__dirname + '/../../sanitizer'));
+
+module.exports = {
+  canCreate: function(request, reply) {
+    // isAdmin or part of conversation
+    var userId = request.auth.credentials.id;
+    var authenticated = request.auth.isAuthenticated;
+    var username = request.auth.credentials.username;
+    var conversationId = request.payload.conversation_id;
+
+    var isAdmin = commonPre.isAdmin(authenticated, username);
+    var isMember = isConversationMember(conversationId, userId);
+
+    var promise = Promise.join(isAdmin, isMember, function(admin, member) {
+      var result = Boom.badRequest();
+      if (admin) { result = ''; }
+      else if (member) { result = ''; }
+      return result;
+    });
+    return reply(promise);
+  },
+  canDelete: function(request, reply) {
+    // isAdmin or message sender
+    var userId = request.auth.credentials.id;
+    var authenticated = request.auth.isAuthenticated;
+    var username = request.auth.credentials.username;
+    var messageId = request.params.id;
+
+    var isAdmin = commonPre.isAdmin(authenticated, username);
+    var isSender = isMessageSender(messageId, userId);
+
+    var promise = Promise.join(isAdmin, isSender, function(admin, sender) {
+      var result = Boom.badRequest();
+      if (admin) { result = ''; }
+      else if (sender) { result = ''; }
+      return result;
+    });
+    return reply(promise);
+  },
+  clean: function(request, reply) {
+    request.payload.body = sanitizer.bbcode(request.payload.body);
+    return reply();
+  },
+  parseEncodings: function(request, reply) {
+    var raw_body = request.payload.body;
+    // check if raw_body has any bbcode
+    if (raw_body.indexOf('[') >= 0) {
+      // convert all (<, &lt;) and (>, &gt;) to decimal to escape the regex
+      // in the bbcode parser that'll unescape those chars
+      raw_body = raw_body.replace(/(?:<|&lt;)/g, '&#60;');
+      raw_body = raw_body.replace(/(?:>|&gt;)/g, '&#62;');
+
+      // convert all unicode characters to their numeric representation
+      // this is so we can save it to the db and present it to any encoding
+      raw_body = textToEntities(raw_body);
+
+      // save back to request.payload.body
+      request.payload.body = bbcodeParser.process({text: raw_body}).html;
+    }
+
+    return reply();
+  }
+};
+
+function textToEntities(text) {
+  var entities = "";
+  for (var i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) > 127) {
+      entities += "&#" + text.charCodeAt(i) + ";";
+    }
+    else { entities += text.charAt(i); }
+  }
+
+  return entities;
+}
+
+function isConversationMember(conversationId, userId) {
+  return db.conversations.isConversationMember(conversationId, userId)
+  .then(function(isMember) { return isMember; });
+}
+
+function isMessageSender(messageId, userId) {
+  return db.messages.isMessageSender(messageId, userId)
+  .then(function(isSender) { return isSender; });
+}


### PR DESCRIPTION
Implemented a page for private messages. This includes all the backend
work to create all the routes necessary to serve out the private
messages and conversations, create messages and conversations, and
delete those if needed. The encompassing work also includes all the
business logic to determine who can create new messages and who are
allowed to delete messages and conversations.

A new directive to handle checking usernames again user ids was also
created to help the user.

The view itself lists the conversation sorted by time on the left hand
side, while the user can choose to view messages which will appear on
the right hand side. A few other items where created to help the user
such as scrolling to the most recent message on loading a conversation.

Testing Procedures:
- go to the messages view
- create a conversation
- create a message
- delete message
- delete last message in conversation
- ensure conversation no longer exists
- create more than 15 conversations
- create more than 15 message in one conversation
- ensure anchor scrolling works on conversation load
- ensure pagination works
- ensure conversations and message are sorted by created_at DESC

Must be test with the same branch name in epochtalk/core-pg