### PR TITLE
Db count position

### DIFF
--- a/app/board/board.data.html
+++ b/app/board/board.data.html
@@ -38,7 +38,7 @@
       </div>
       <div ng-if="childBoard.last_thread_title">
         in thread
-        <a ui-sref="posts.data({ threadId: childBoard.last_thread_id })" ng-bind-html="childBoard.last_thread_title | truncate:25"></a>
+        <a ui-sref="posts.data({ threadId: childBoard.last_thread_id, start: childBoard.last_post_position })" ng-bind-html="childBoard.last_thread_title | truncate:25"></a>
       </div>
       <div ng-if="childBoard.last_post_created_at">
         <span ng-bind="childBoard.last_post_created_at | humanDate"></span>

--- a/app/boards/boards.html
+++ b/app/boards/boards.html
@@ -55,7 +55,7 @@
         </div>
         <div ng-if="board.last_thread_title">
           in thread
-          <a ui-sref="posts.data({ threadId: board.last_thread_id })" ng-bind-html="::board.last_thread_title | truncate:25"></a>
+          <a ui-sref="posts.data({ threadId: board.last_thread_id, start: board.last_post_position })" ng-bind-html="::board.last_thread_title | truncate:25"></a>
         </div>
         <div ng-if="board.last_post_created_at">
           <i ng-bind="::board.last_post_created_at | humanDate"></i>

--- a/app/components/pagination/pagination.directive.js
+++ b/app/components/pagination/pagination.directive.js
@@ -59,6 +59,7 @@ module.exports = ['$location', '$filter', function($location, $filter) {
         if (scope.page > 1) {
           prevBtnKey.class = 'arrow';
           opts = angular.copy($location.search());
+          opts.start = null;
           opts.page = (scope.page - 1);
           prevBtnKey.opts = opts;
           scope.paginationKeys.push(prevBtnKey);
@@ -84,6 +85,7 @@ module.exports = ['$location', '$filter', function($location, $filter) {
           }
           else {
             opts = angular.copy($location.search());
+            opts.start = null;
             opts.page = index;
             pageKey = {
               val: $filter('number')(index, 0),
@@ -99,6 +101,7 @@ module.exports = ['$location', '$filter', function($location, $filter) {
         var nextBtnKey = { val: '&#10095;' };
         if (scope.page < scope.pageCount) {
           opts = angular.copy($location.search());
+          opts.start = null;
           opts.page = (scope.page + 1);
           nextBtnKey.class = 'arrow';
           nextBtnKey.opts = opts;

--- a/app/config.js
+++ b/app/config.js
@@ -216,7 +216,7 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
       }
     })
     .state('posts.data', {
-      url: '/threads/{threadId}/posts?limit&page',
+      url: '/threads/{threadId}/posts?limit&page&start',
       reloadOnSearch: false,
       views: {
         'data@posts': {
@@ -230,8 +230,9 @@ module.exports = ['$stateProvider', '$urlRouterProvider', '$locationProvider', '
         pageData: ['Posts', 'Threads', '$stateParams', function(Posts, Threads, $stateParams) {
           var query = {
             thread_id: $stateParams.threadId,
-            page: Number($stateParams.page) || 1,
-            limit: Number($stateParams.limit) || 25
+            page: $stateParams.page,
+            limit: $stateParams.limit,
+            start: $stateParams.start
           };
           Threads.viewed({ id: $stateParams.threadId });
           return Posts.byThread(query).$promise;

--- a/app/posts/posts.controller.js
+++ b/app/posts/posts.controller.js
@@ -3,8 +3,8 @@ module.exports = [
   function($rootScope, $scope, $timeout, $anchorScroll, $location, Session, Threads, Posts, pageData) {
     var ctrl = this;
     var parent = $scope.$parent.PostsParentCtrl;
-    parent.page = Number(pageData.page) || 1;
-    parent.limit = Number(pageData.limit) || 25;
+    parent.page = Number(pageData.page);
+    parent.limit = Number(pageData.limit);
     parent.posts = pageData.posts;
     parent.thread = pageData.thread;
     parent.board_id = pageData.thread.board_id;
@@ -33,8 +33,8 @@ module.exports = [
 
     this.offLCS = $rootScope.$on('$locationChangeSuccess', function(event){
       var params = $location.search();
-      var page = Number(params.page) || 1;
-      var limit = Number(params.limit) || 25;
+      var page = Number(params.page);
+      var limit = Number(params.limit);
       var pageChanged = false;
       var limitChanged = false;
 

--- a/app/posts/posts.data.html
+++ b/app/posts/posts.data.html
@@ -48,7 +48,7 @@
           </a>
         </li>
         <li>
-          <a ng-href="{{PostsCtrl.rootUrl}}#{{post.id}}" ng-click="PostsCtrl.highlightPost()" class="css-tooltip" data-css-tooltip="Permalink">
+          <a ng-href="{{::PostsCtrl.rootUrl}}?start={{::post.position}}#{{::post.id}}" ng-click="PostsCtrl.highlightPost()" class="css-tooltip" data-css-tooltip="Permalink">
             <i class="icon-epoch-link"></i>
           </a>
         </li>

--- a/app/services/breadcrumbs.js
+++ b/app/services/breadcrumbs.js
@@ -33,6 +33,7 @@ function ($stateParams, $location, Breadcrumbs) {
       // Strip query str params since stateParams includes query and route params together
       delete routeParams.limit;
       delete routeParams.page;
+      delete routeParams.start;
 
       // Maps routeParams key to breadcrumb type
       var keyToType = {

--- a/app/user/posts.html
+++ b/app/user/posts.html
@@ -18,7 +18,7 @@
     </thead>
     <tbody>
       <tr ng-repeat="post in ProfilePostsCtrl.usersPosts track by post.id">
-        <td><a ui-sref="posts.data({ threadId: post.thread_id, '#': post.id })" ng-bind-html="post.thread_title | truncate:50"></a></td>
+        <td><a ui-sref="posts.data({ threadId: post.thread_id, start: post.position, '#': post.id })" ng-bind-html="post.thread_title | truncate:50"></a></td>
         <td ng-bind="(post.raw_body || post.body) | truncate:250"></td>
         <td ng-bind="post.created_at | humanDate"></td>
       </tr>


### PR DESCRIPTION
Migrations to add post positions to posts and boards for faster linking to thread pages.

Testing procedures:

* Create post and ensure post counts on users, threads, and boards are updated.
* Delete post and ensure post counts on users, threads, and boards are updated.
* Same for threads.
* Set at least two threads to be sticky and create a post to change their order
* Create a post and ensure that the last post on the home page is correct and links to the last page of the thread.