### PR TITLE
Implemented the unread link, code refactoring

### DIFF
--- a/app/board/board.data.html
+++ b/app/board/board.data.html
@@ -97,8 +97,7 @@
 
     <div class="pages" ng-if="thread.page_count > 1">
       <span ng-repeat="pageKey in thread.page_keys">
-        <a ng-if="pageKey.threadId !== null && pageKey.val !== 'All'" ui-sref="posts.data({ threadId: pageKey.threadId, page: pageKey.val })" ng-bind-html="pageKey.val"></a>
-        <a ng-if="pageKey.val === 'All'" ui-sref="posts.data({ threadId: pageKey.threadId, page: 1, limit: 'all' })" ng-bind-html="pageKey.val"></a>
+        <a ng-if="pageKey.threadId !== null" ui-sref="posts.data({ threadId: pageKey.threadId, page: pageKey.val })" ng-bind-html="pageKey.val"></a>
         <span ng-if="pageKey.threadId === null" ng-bind-html="pageKey.val"></span>
       </span>
     </div>
@@ -109,8 +108,12 @@
   <div class="views" ng-bind="thread.view_count | number:0"></div>
 
   <div class="last-reply">
-    Last post by <a ui-sref="profile({ username: thread.last_post_username })" ng-bind-html="thread.last_post_username"></a>
+    <a ui-sref="posts.data({ threadId: thread.id, start: thread.last_post_position, '#': thread.last_post_id })">Last post</a>
+     by <a ui-sref="profile({ username: thread.last_post_username })" ng-bind-html="thread.last_post_username"></a>
     <div ng-bind="thread.last_post_created_at | humanDate"></div>
+    <div ng-if="thread.has_new_post">
+      <a ui-sref="posts.data({ threadId: thread.id, start: thread.latest_unread_position, '#': thread.latest_unread_post_id })">Last unread post</a>
+    </div>
   </div>
 </div>
 
@@ -140,8 +143,7 @@
 
     <div class="pages" ng-if="thread.page_count > 1">
       <span ng-repeat="pageKey in thread.page_keys">
-        <a ng-if="pageKey.threadId !== null && pageKey.val !== 'All'" ui-sref="posts.data({ threadId: pageKey.threadId, page: pageKey.val })" ng-bind-html="pageKey.val"></a>
-        <a ng-if="pageKey.val === 'All'" ui-sref="posts.data({ threadId: pageKey.threadId, page: 1, limit: 'all' })" ng-bind-html="pageKey.val"></a>
+        <a ng-if="pageKey.threadId !== null" ui-sref="posts.data({ threadId: pageKey.threadId, page: pageKey.val })" ng-bind-html="pageKey.val"></a>
         <span ng-if="pageKey.threadId === null" ng-bind-html="pageKey.val"></span>
       </span>
     </div>
@@ -152,7 +154,11 @@
   <div class="views" ng-bind="thread.view_count | number:0"></div>
 
   <div class="last-reply">
-    Last post by <a ui-sref="profile({ username: thread.last_post_username })" ng-bind-html="thread.last_post_username"></a>
+    <a ui-sref="posts.data({ threadId: thread.id, start: thread.last_post_position, '#': thread.last_post_id })">Last post</a>
+    by <a ui-sref="profile({ username: thread.last_post_username })" ng-bind-html="thread.last_post_username"></a>
     <div ng-bind="thread.last_post_created_at | humanDate"></div>
+    <div ng-if="thread.has_new_post">
+      <a ui-sref="posts.data({ threadId: thread.id, start: thread.latest_unread_position, '#': thread.latest_unread_post_id })">Last unread post</a>
+    </div>
   </div>
 </div>

--- a/app/posts/posts.controller.js
+++ b/app/posts/posts.controller.js
@@ -15,7 +15,7 @@ var ctrl = [
     this.loadEditor = parent.loadEditor;
     this.addQuote = parent.addQuote;
     this.openReportModal = parent.openReportModal;
-    $timeout($anchorScroll);
+    $timeout($anchorScroll, 100);
 
     // Get access rights to page controls for authed user
     this.controlAccess = Session.getControlAccess('postControls', pageData.thread.board_id);


### PR DESCRIPTION
Some of the user thread view code was refactored to be cleaner and more
readable. In particular, the code that checks to see if a user view is
valid has been updated to be smaller and more maintainable.

The threads.byBoard was also updated to push as much of the thread
viewed checking to the DB as possible. This should cut down the latency
within this method. With that, the front end was updated with links to
the very last post in a thread, and a link to the last unread post since
the user last visited that page.

TESTING PROCEDURES:
 * build as usual
 * using a main account, pick a thread and view it
 * using an alt account, add a post to the previous thread
 * using the main account in the thread view, look for the previous thread and ensure that it's title is bold and there is a 'last unread post' link on the right. 
 * click on 'last unread post'
 * ensure that the previous thread's post page is returned and the correct page (latest page) is already in view 
 * ensure that the post made by the alt account is highlighted. 

This is a branch needs to be run in conjunction with the branch of the same name in core-pg.