### PR TITLE
Dotenv

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,1 @@
 server: node server
-build: npm run db-migrate && npm run build
-initialize: node cli/index.js --create

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,0 @@
-server: npm run serve

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Next generation forum software. Epochtalk is a forum frontend designed to be pai
 * [npm](https://www.npmjs.org/doc/README.html) (pre-packaged with node)
 * [bower](https://github.com/bower/bower)
 * [Postgres](http://www.postgresql.org/)
-* [foreman](http://ddollar.github.io/foreman)
 
 ### Bower
 * angular `1.4.4`
@@ -120,19 +119,16 @@ $ cp example.env .env
 $ bower install
 ```
 
-#### 5) Initialize with foreman
-First ensure that [Postgres](http://www.postgresql.org/) is installed andrunning. Also ensure that [foreman](http://ddollar.github.io/foreman) is installed. Before running Epochtalk for the first time, it is necessary to setup the database and first user account. The CLI tool will create the first board and admin account for the fourm. From the root directory of the project run the following command:
+#### 5) Initialize
+First ensure that [Postgres](http://www.postgresql.org/) is installed andrunning. Before running Epochtalk for the first time, it is necessary to setup the database and first user account. The CLI tool will create the first board and admin account for the fourm. From the root directory of the project run the following command:
 ```sh
-$ foreman start initialize
+$ node cli --create
 ```
 
 #### 6) Start the Epochtalk server
-Running `foreman build` will compile all JavaScript and css.  The `foreman
-start` command Epochtalk will start the webserver. Once the server is running,
-the forum can be viewed at `http://localhost:8080`
+Running the `npm run serve` command, Epochtalk will start the webserver. Once the server is running, the forum can be viewed at `http://localhost:8080`
 ```sh
-$ foreman start build
-$ foreman start server
+$ npm run serve
 ```
 
 #### 7) Login and change admin account information

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('dotenv').load();
 var path = require('path');
 var program = require('commander');
 var db = require(path.normalize(__dirname + '/../db'));

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "deep-rename-keys": "^0.1.0",
     "del": "^1.1.1",
     "dot": "^1.0.3",
+    "dotenv": "^1.2.0",
     "epochtalk-bbcode-parser": "^1.0.0",
     "epochtalk-core-pg": "epochtalk/core-pg",
     "fs-extra": "^0.16.5",

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,3 +1,4 @@
+require('dotenv').load();
 var path = require('path');
 var nodemon = require('nodemon');
 var sass = require(path.join(__dirname, 'tasks', 'sass'));

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+require('dotenv').load();
 var _ = require('lodash');
 var path = require('path');
 var Hapi = require('hapi');


### PR DESCRIPTION
load .env with npm dotenv instead of foreman.  this way, the user can run `foreman start` by itself with no arguments.
updated documentation to run for devs