### PR TITLE
Moderated threads

### DIFF
--- a/app/admin/management/roles.html
+++ b/app/admin/management/roles.html
@@ -725,6 +725,11 @@
               <input id="polls-vote" type="checkbox" ng-model="AdminManagementCtrl.newRole.permissions.polls.vote" ng-change="AdminManagementCtrl.newRole.permissions.polls.vote ? AdminManagementCtrl.newRole.permissions.threads.byBoard = true : null" ng-false-value="undefined" />
               Allow user to vote on polls
             </label>
+            <!-- Moderate Thread -->
+            <label>
+              <input id="threads-moderate" type="checkbox" ng-model="AdminManagementCtrl.newRole.permissions.threads.moderated" ng-false-value="undefined" />
+              Allow user to moderate threads (delete)
+            </label>
           </div>
           <div class="half-column">
             <!-- Edit Thread Title -->

--- a/app/board/new-thread.html
+++ b/app/board/new-thread.html
@@ -41,42 +41,14 @@
       <label for="stickyThread">Sticky Thread</label>
     </div>
 
+    <div class="option" ng-if="NewThreadCtrl.controlAccess.moderated">
+      <input type="checkbox" id="moderateThread" ng-model="NewThreadCtrl.thread.moderated" ng-disabled="!NewThreadCtrl.loggedIn()">
+      <label for="moderateThread">Moderate Thread</label>
+    </div>
+
     <div class="option" ng-if="NewThreadCtrl.pollControlAccess.create">
       <input type="checkbox" id="threadPoll" ng-model="NewThreadCtrl.addPoll" ng-disabled="!NewThreadCtrl.loggedIn()">
       <label for="threadPoll">Add a Poll</label>
-    </div>
-  </div>
-
-  <!-- polls -->
-  <div class="fill-row" ng-if="NewThreadCtrl.addPoll" style="border: 1px solid #ddd; border-radius: 5px; margin-top: 20px; padding: 1rem 1rem 0 1rem;">
-    <!-- Poll Question -->
-    <div class="fill-row">
-      <div class="option">
-        <label for="stickyThread">Question:</label>
-        <input type="text" id="stickyThread" ng-model="NewThreadCtrl.poll.question" ng-disabled="!NewThreadCtrl.loggedIn()">
-      </div>
-    </div>
-    <hr class="fill-row"/>
-    <!-- Poll Answers -->
-    <div class="fill-row" ng-repeat="answer in NewThreadCtrl.poll.answers track by $index" style="padding-bottom: 10px; height: 70px">
-      <div class="option">
-        <label for="stickyThread">Answer:</label>
-        <div style="position: relative">
-          <div style="position: absolute; left: 0; right: 50px;">
-            <input type="text" id="stickyThread" ng-model="NewThreadCtrl.poll.answers[$index]" ng-disabled="!NewThreadCtrl.loggedIn()">
-          </div>
-          <button ng-click="NewThreadCtrl.removePollAnswer($index)" style="position: absolute; right: 0; width: 25px; margin-bottom: 0; text-align: center;"><i class="fa fa-minus-circle"></i>
-          </button>
-        </div>
-      </div>
-    </div>
-    <!-- Add Answer Button -->
-    <div class="fill-row" style="padding-top: 10px">
-      <div class="option">
-        <button ng-click="NewThreadCtrl.addPollAnswer()" ng-disabled="!NewThreadCtrl.loggedIn() || NewThreadCtrl.poll.answers.length > 7" style="width: 100%">
-          Add Answer
-        </button>
-      </div>
     </div>
   </div>
 </div>

--- a/app/posts/parent.controller.js
+++ b/app/posts/parent.controller.js
@@ -245,61 +245,52 @@ var ctrl = [
 
     this.deletePostIndex = -1;
     this.showDeleteModal = false;
-    this.closeDeleteModal = function() {
-      $timeout(function() { ctrl.showDeleteModal = false; });
-    };
     this.openDeleteModal = function(index) {
       ctrl.deletePostIndex = index;
       ctrl.showDeleteModal = true;
     };
     this.deletePost = function() {
+      ctrl.showDeleteModal = false;
       var index = ctrl.deletePostIndex;
       var post = ctrl.posts && ctrl.posts[index] || '';
       if (post) {
         Posts.delete({id: post.id}).$promise
-        .then(function() { post.deleted = true; })
-        .catch(function() { Alert.error('Failed to delete post'); })
-        .finally(function() { ctrl.showDeleteModal = false; });
+        .then(function() { $state.go($state.$current, null, {reload:true}); })
+        .catch(function() { Alert.error('Failed to delete post'); });
       }
     };
 
     this.undeletePostIndex = -1;
     this.showUndeleteModal = false;
-    this.closeUndeleteModal = function() {
-      $timeout(function() { ctrl.showUndeleteModal = false; });
-    };
     this.openUndeleteModal = function(index) {
       ctrl.undeletePostIndex = index;
       ctrl.showUndeleteModal = true;
     };
     this.undeletePost = function() {
+      ctrl.showUndeleteModal = false;
       var index = ctrl.undeletePostIndex;
       var post = ctrl.posts && ctrl.posts[index] || '';
       if (post) {
         Posts.undelete({id: post.id}).$promise
-        .then(function() { post.deleted = false; })
-        .catch(function() { Alert.error('Failed to Undelete Post'); })
-        .finally(function() { ctrl.showUndeleteModal = false; });
+        .then(function() { $state.go($state.$current, null, {reload:true}); })
+        .catch(function() { Alert.error('Failed to Undelete Post'); });
       }
     };
 
     this.purgePostIndex = -1;
     this.showPurgeModal = false;
-    this.closePurgeModal = function() {
-      $timeout(function() { ctrl.showPurgeModal = false; });
-    };
     this.openPurgeModal = function(index) {
       ctrl.purgePostIndex = index;
       ctrl.showPurgeModal = true;
     };
     this.purgePost = function() {
+      ctrl.showPurgeModal = false;
       var index = ctrl.purgePostIndex;
       var post = ctrl.posts && ctrl.posts[index] || '';
       if (post) {
         Posts.purge({id: post.id}).$promise
         .then(function() { $state.go($state.$current, null, {reload:true}); })
-        .catch(function() { Alert.error('Failed to purge Post'); })
-        .finally(function() { ctrl.showPurgeModal = false; });
+        .catch(function() { Alert.error('Failed to purge Post'); });
       }
     };
 

--- a/app/posts/posts.controller.js
+++ b/app/posts/posts.controller.js
@@ -20,6 +20,7 @@ var ctrl = [
 
     // Get access rights to page controls for authed user
     this.controlAccess = Session.getControlAccess('postControls', pageData.thread.board_id);
+    this.moderatedControlAccess = Session.getControlAccess('threadControls.moderated');
 
     // init function
     (function() {

--- a/app/posts/posts.data.html
+++ b/app/posts/posts.data.html
@@ -23,12 +23,12 @@
             <i class="fa fa-trash"></i>
           </a>
         </li>
-        <li ng-if="((post.user.id === PostsCtrl.user.id && PostsCtrl.controlAccess.delete) || PostsCtrl.controlAccess.privilegedDelete) && $index !== 0 && !post.deleted">
+        <li ng-if="((post.user.id === PostsCtrl.user.id && PostsCtrl.controlAccess.delete) || PostsCtrl.controlAccess.privilegedDelete || (PostsCtrl.thread.user.id === PostsCtrl.user.id && PostsCtrl.thread.moderated && PostsCtrl.moderatedControlAccess)) && $index !== 0 && !post.deleted">
           <a ng-href="#" class="css-tooltip" data-css-tooltip="Delete" ng-click="PostsParentCtrl.openDeleteModal($index)">
             <i class="fa fa-eye-slash"></i>
           </a>
         </li>
-        <li ng-if="((post.user.id === PostsCtrl.user.id && PostsCtrl.controlAccess.undelete) || PostsCtrl.controlAccess.privilegedDelete) && post.deleted === true">
+        <li ng-if="((post.user.id === PostsCtrl.user.id && PostsCtrl.controlAccess.undelete) || PostsCtrl.controlAccess.privilegedDelete || (PostsCtrl.thread.user.id === PostsCtrl.user.id && PostsCtrl.thread.moderated && PostsCtrl.moderatedControlAccess)) && post.deleted === true">
           <a ng-href="#" class="css-tooltip" data-css-tooltip="Undelete" ng-click="PostsParentCtrl.openUndeleteModal($index)">
             <i class="fa fa-eye"></i>
           </a>
@@ -66,7 +66,7 @@
 </div>
 
 <!-- Delete Post Modal -->
-<modal show="PostsParentCtrl.showDeleteModal" on-close="PostsParentCtrl.closeDeleteModal()">
+<modal show="PostsParentCtrl.showDeleteModal">
   <form name="$parent.form" class="css-form" novalidate>
     <h3 class="thin-underline">Delete Post</h3>
     <p>Are you sure you want to delete this post?</p>
@@ -80,7 +80,7 @@
 </modal>
 
 <!-- Undelete Post Modal -->
-<modal show="PostsParentCtrl.showUndeleteModal" on-close="PostsParentCtrl.closeUndeleteModal()">
+<modal show="PostsParentCtrl.showUndeleteModal">
   <form name="$parent.form" class="css-form" novalidate>
     <h3 class="thin-underline">Undelete Post</h3>
     <p>Are you sure you want to Undelete this post?</p>
@@ -94,7 +94,7 @@
 </modal>
 
 <!-- Purge Post Modal -->
-<modal show="PostsParentCtrl.showPurgeModal" on-close="PostsParentCtrl.closePurgeModal()">
+<modal show="PostsParentCtrl.showPurgeModal">
   <form name="$parent.form" class="css-form" novalidate>
     <h3 class="thin-underline">Purge Post</h3>
     <p>Are you sure you want to permanently delete this post?</p>

--- a/app/posts/posts.html
+++ b/app/posts/posts.html
@@ -1,3 +1,8 @@
+<!-- Moderated Thread Banner -->
+<div class="banner warning" ng-if="PostsParentCtrl.thread.moderated">
+  Moderated Thread - <em>Thread starter can <strong>delete</strong> posts.</em>
+</div>
+
 <!-- Page Title -->
 <div class="page-header-split">
   <!-- Show Title -->

--- a/app/scss/ept/_ept.scss
+++ b/app/scss/ept/_ept.scss
@@ -948,6 +948,16 @@ table.striped {
   }
 }
 
+.banner {
+  @include span-columns(12);
+  @include border-radius(5px);
+  border: 1px solid $border-color;
+  margin-bottom: 1rem;
+  padding: 0.875rem;
+  text-align: center;
+  &.warning { background-color: #FCFC79; }
+}
+
 /*-------------- Index File -------------- */
 
 #wrapper { min-height:100%; position:relative; }

--- a/server/plugins/acls/roles.js
+++ b/server/plugins/acls/roles.js
@@ -195,6 +195,7 @@ module.exports = roles;
       lock: true,
       sticky: true,
       move: true,
+      moderated: true,
       purge: true
     },
     polls: {
@@ -409,6 +410,7 @@ roles.superAdministrator = {
     lock: true,
     sticky: true,
     move: true,
+    moderated: true,
     purge: true
   },
   polls: {
@@ -599,6 +601,7 @@ roles.administrator = {
     lock: true,
     sticky: true,
     move: true,
+    moderated: true,
     purge: true
   },
   polls: {
@@ -746,6 +749,7 @@ roles.globalModerator = {
     lock: true,
     sticky: true,
     move: true,
+    moderated: true,
     purge: true
   },
   polls: {
@@ -883,6 +887,7 @@ roles.moderator = {
     lock: true,
     sticky: true,
     move: true,
+    moderated: true,
     purge: true
   },
   polls: {
@@ -943,6 +948,7 @@ roles.user = {
     byBoard: true,
     viewed: true,
     title: true,
+    moderated: true,
     lock: true
   },
   polls: {

--- a/server/routes/admin/roles/config.js
+++ b/server/routes/admin/roles/config.js
@@ -292,6 +292,7 @@ exports.add = {
           lock: Joi.boolean(),
           sticky: Joi.boolean(),
           move: Joi.boolean(),
+          moderated: Joi.boolean(),
           purge: Joi.boolean()
         }),
         users: Joi.object().keys({
@@ -567,6 +568,7 @@ exports.update = {
           lock: Joi.boolean(),
           sticky: Joi.boolean(),
           move: Joi.boolean(),
+          moderated: Joi.boolean(),
           purge: Joi.boolean()
         }),
         users: Joi.object().keys({

--- a/server/routes/auth/helper.js
+++ b/server/routes/auth/helper.js
@@ -99,7 +99,8 @@ function getMaskedPermissions(userRoles) {
       } : undefined,
       create: maskPermission('threads.create'),
       title: maskPermission('threads.title'),
-      lock: maskPermission('threads.lock')
+      lock: maskPermission('threads.lock'),
+      moderated: maskPermission('threads.moderated')
     },
     pollControls: {
       privilegedLock: maskPermission('polls.privilegedLock') ? {

--- a/server/routes/posts/config.js
+++ b/server/routes/posts/config.js
@@ -296,14 +296,14 @@ exports.update = {
 exports.delete = {
   app: {
     post_id: 'params.id',
-    isPostOwner: 'posts.privilegedDelete'
+    isPostDeletable: 'posts.privilegedDelete'
   },
   auth: { strategy: 'jwt' },
   plugins: { acls: 'posts.delete' },
   validate: { params: { id: Joi.string().required() } },
   pre: [ [
     { method: pre.isCDRPost },
-    { method: pre.isPostOwner },
+    { method: pre.isPostDeletable },
     { method: pre.accessBoardWithPostId },
     { method: pre.accessLockedThreadWithPostId },
     { method: pre.isRequesterActive }
@@ -333,14 +333,14 @@ exports.delete = {
 exports.undelete = {
   app: {
     post_id: 'params.id',
-    isPostOwner: 'posts.privilegedDelete'
+    isPostDeletable: 'posts.privilegedDelete'
   },
   auth: { strategy: 'jwt' },
   plugins: { acls: 'posts.undelete' },
   validate: { params: { id: Joi.string().required() } },
   pre: [ [
     { method: pre.isCDRPost },
-    { method: pre.isPostOwner },
+    { method: pre.isPostDeletable },
     { method: pre.accessBoardWithPostId },
     { method: pre.accessLockedThreadWithPostId },
     { method: pre.isRequesterActive }

--- a/server/routes/threads/config.js
+++ b/server/routes/threads/config.js
@@ -34,6 +34,7 @@ exports.create = {
     payload: Joi.object().keys({
       locked: Joi.boolean().default(false),
       sticky: Joi.boolean().default(false),
+      moderated: Joi.boolean().default(false),
       title: Joi.string().min(1).max(255).required(),
       body: Joi.string().allow(''),
       raw_body: Joi.string().required(),
@@ -54,7 +55,8 @@ exports.create = {
       { method: pre.isRequesterActive },
       { method: pre.isPollCreatable },
       { method: pre.validateMaxAnswers },
-      { method: pre.validateDisplayMode }
+      { method: pre.validateDisplayMode },
+      { method: pre.canModerate }
     ],
     { method: postPre.clean },
     { method: postPre.parseEncodings },
@@ -66,7 +68,8 @@ exports.create = {
     var newThread = {
       board_id: request.payload.board_id,
       locked: request.payload.locked,
-      sticky: request.payload.sticky
+      sticky: request.payload.sticky,
+      moderated: request.payload.moderated
     };
     var newPost = {
       title: request.payload.title,

--- a/server/routes/threads/pre.js
+++ b/server/routes/threads/pre.js
@@ -263,6 +263,17 @@ module.exports = {
 
     return reply(promise);
   },
+  canModerate: function(request, reply) {
+    if (!request.payload.moderated) { return reply(); }
+
+    var userId = request.auth.credentials.id;
+    var getACLValue = request.server.plugins.acls.getACLValue;
+    var hasPrivilege = getACLValue(request.auth, 'threads.moderated');
+    var result = Boom.forbidden();
+    if (hasPrivilege) { result = true; }
+
+    return reply(result);
+  },
   getThread: function(request, reply) {
     var threadId = _.get(request, request.route.settings.app.thread_id);
     db.threads.find(threadId)


### PR DESCRIPTION
Added the ability for users with the threads.moderate permission to flip
a switch which allows them to moderate their own thread. This allows
that user to delete and undelete posts made by other users.

Testing Procedures:
- Using a regular user account, create a thread with self moderating flag on
- Create a post by another regular user into the above thread.
- Using the first account, moderate the second post