### PR TITLE
upgrade modules on docker cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ MAINTAINER boka <boka@slickage.com>
 RUN npm update epochtalk-core-pg
 RUN npm install -g bower
 RUN bower install --allow-root
-CMD npm run db-migrate && npm run serve
+CMD npm run db-migrate && npm --prefix ./modules upgrade && npm run serve
 EXPOSE 8080


### PR DESCRIPTION
this update calls `npm update` on modules when running the docker container
this is currently necessary to keep module deps up to date with their respective master branches (because they are hosted on github)