### PR TITLE
Updated admin user search/count routes to allow ip searching

### DIFF
--- a/server/routes/admin/users/config.js
+++ b/server/routes/admin/users/config.js
@@ -198,17 +198,20 @@ exports.count = {
   validate: {
     query: {
       filter: Joi.string().valid('banned'),
-      search: Joi.string()
+      search: Joi.string(),
+      ip: Joi.boolean()
     }
   },
   handler: function(request, reply) {
     var opts;
     var filter = request.query.filter;
     var search = request.query.search;
+    var ip = request.query.ip;
     if (filter || search) {
       opts = {
         filter: filter,
-        searchStr: search
+        searchStr: search,
+        ip: ip
       };
     }
 
@@ -253,7 +256,8 @@ exports.page = {
       field: Joi.string().default('username').valid('username', 'email', 'updated_at', 'created_at', 'imported_at', 'ban_expiration'),
       desc: Joi.boolean().default(false),
       filter: Joi.string().valid('banned'),
-      search: Joi.string()
+      search: Joi.string(),
+      ip: Joi.boolean()
     }
   },
   handler: function(request, reply) {
@@ -263,7 +267,8 @@ exports.page = {
       sortField: request.query.field,
       sortDesc: request.query.desc,
       filter: request.query.filter,
-      searchStr: request.query.search
+      searchStr: request.query.search,
+      ip: request.query.ip
     };
     var promise = request.db.users.page(opts);
     return reply(promise);


### PR DESCRIPTION
Test Procedure:

1) Checkout epochtalk, ept-frontent and ept-users
2) Start server and visit Admin->Management->Users
3) From the drop down select "Search users by ip address"
4) Type an ip or ip wildcard (e.g. 127.0.0.1 or 127.%.%.%)

NOTE: For now I'm just supporting ip or ip wildcard, since a range search would require modification of the db. Im going to ask theymos if this is sufficient or if he needs a true range search. For the most part I assume searching for something like 64.55.43.% should give you a sense of if a user is creating multiple accounts