### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Next generation forum software. Epochtalk is a forum frontend designed to be pai
 * mkdirp `^0.5.0`
 * mmmagic `^0.4.1`
 * node-sass `^3.4.2`
-* node-uuid `^1.4.1`
+* uuid `^3.0.0`
 * nodemailer `^2.0.0`
 * oclazyload `^1.0.6`
 * pg `^4.2.0`

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "mmmagic": "^0.4.1",
     "node-sass": "^3.4.2",
     "node-sass-globbing": "0.0.23",
-    "node-uuid": "^1.4.1",
     "nodemailer": "^2.0.0",
     "oclazyload": "^1.0.6",
     "pg": "^4.2.0",
@@ -70,6 +69,7 @@
     "socketcluster-client": "^4.3.7",
     "stream-meter": "^1.0.3",
     "through2": "^2.0.0",
+    "uuid": "^3.0.0",
     "vision": "^4.0.1",
     "webpack": "^1.12.2"
   },

--- a/server/plugins/session/index.js
+++ b/server/plugins/session/index.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var jwt = require('jsonwebtoken');
 var session = {};
 var redis, config, roles;


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.