### PR TITLE
S3 saas refactor (no longer require s3 list all buckets permissions)

### DIFF
--- a/server/plugins/imageStore/s3.js
+++ b/server/plugins/imageStore/s3.js
@@ -162,12 +162,7 @@ s3.init = function(opts) {
 
   if (config.images.storage === 's3') {
     s3.initClient()
-    .then(s3.checkAccount)
-    .then(function() {
-      return s3.checkBucket()
-      // bucket does not exist
-      .catch(function() { return s3.createBucket(); });
-    })
+    .then(s3.checkBucket)
     .catch(function(error) { console.log('S3 Integration is Broken', error); });
   }
 };
@@ -184,15 +179,6 @@ s3.initClient = function(accessKey, secretKey, region) {
   });
   client = new AWS.S3();
   return Promise.resolve(client);
-};
-
-s3.checkAccount = function() {
-  return new Promise(function(resolve, reject) {
-    client.listBuckets(function(err, data) {
-      if (err) { return reject(err); }
-      if (data) { return resolve(data); }
-    });
-  });
 };
 
 s3.checkBucket = function() {

--- a/server/plugins/imageStore/s3.js
+++ b/server/plugins/imageStore/s3.js
@@ -168,7 +168,7 @@ s3.init = function(opts) {
       // bucket does not exist
       .catch(function() { return s3.createBucket(); });
     })
-    .catch(function() { console.log('S3 Integration is Broken'); });
+    .catch(function(error) { console.log('S3 Integration is Broken', error); });
   }
 };
 

--- a/server/plugins/imageStore/s3.js
+++ b/server/plugins/imageStore/s3.js
@@ -162,7 +162,11 @@ s3.init = function(opts) {
 
   if (config.images.storage === 's3') {
     s3.initClient()
-    .then(s3.checkBucket)
+    .then(function() {
+      return s3.checkBucket()
+      // bucket does not exist
+      .catch(function() { return s3.createBucket(); });
+    })
     .catch(function(error) { console.log('S3 Integration is Broken', error); });
   }
 };


### PR DESCRIPTION
As a security feature, each epochtalk instance should be locked down to the minimum permissions...  Only allow create/list, set acl, get acl, etc. on the instances' own bucket.  This update removes the check for listing all buckets for a user and keeps the check that the epochtalk instance can access its own bucket.