### PR TITLE
Fix watcher to watch local modules. Version bump for external modules

### DIFF
--- a/modules/ept-frontend/client/scss/ept/views/public/_profile.scss
+++ b/modules/ept-frontend/client/scss/ept/views/public/_profile.scss
@@ -68,7 +68,7 @@
     }
   }
 }
-.profile-posts, & {
+.profile-posts {
   .profile-row {
     .title { @include span-columns(3); font-weight: 600; }
     .pagination-wrap {

--- a/modules/package.json
+++ b/modules/package.json
@@ -9,7 +9,7 @@
   "author": "Edward Kim",
   "license": "ISC",
   "dependencies": {
-    "bct-activity": "~1.0.1",
-    "bct-trust": "1.0.3"
+    "bct-activity": "1.0.2",
+    "bct-trust": "1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "marked": "^0.3.6",
     "mkdirp": "^0.5.0",
     "mmmagic": "^0.4.1",
-    "node-sass": "^4.3.0",
+    "node-sass": "^4.4.0",
     "node-sass-globbing": "0.0.23",
     "nodemailer": "^2.0.0",
     "nodemailer-ses-transport": "^1.5.0",


### PR DESCRIPTION
Resolves #180

Watcher now watches local modules within the /modules directory.

Also fixes issue with external modules bringing in duplicate /modules/node_modules which already exist in the top level /node_modules directory