### PR TITLE
Enforce max size

### DIFF
--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -82,7 +82,7 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
           }
         });
 
-        if (errImages.length) {
+        if (!$scope.currentImages.length) {
           var warningMsg = 'Some images exceeded the max image upload size: [' + errImages.join(', ') + ']';
           return $timeout(function() { Alert.warning(warningMsg); });
         }
@@ -116,6 +116,7 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
               if ($scope.onDone) { $scope.onDone({data: url}); }
               if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { $scope.model = url; }
               else { $scope.images.push(image); }
+              if (warningMsg) { Alert.warning(warningMsg); }
             })
             .catch(function(err) {
               image.progress = '--';

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -82,7 +82,7 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
           }
         });
 
-        if (!$scope.currentImages.length) {
+        if (errImages.length) {
           var warningMsg = `Some images exceeded the max image upload size: [${errImages.join(', ')}]`;
           return $timeout(function() { Alert.warning(warningMsg); });
         }
@@ -116,7 +116,6 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
               if ($scope.onDone) { $scope.onDone({data: url}); }
               if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { $scope.model = url; }
               else { $scope.images.push(image); }
-              if (warningMsg) { Alert.warning(warningMsg); }
             })
             .catch(function(err) {
               image.progress = '--';

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -65,7 +65,6 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
          *   url: {string} The url where the image is hosted (upon upload completion)
          */
          // prep each image
-        var warningMsg = 'Some images exceeded the max image upload size: ';
         var errImages = [];
         fsImages.forEach(function(fsImage) {
           var maxImageSize = forumData.max_image_size;
@@ -83,10 +82,8 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
           }
         });
 
-        // CALCULATE WARNING MESSAGE HERE ITERATE THROUGH errIMAGES
-
-
         if (!$scope.currentImages.length) {
+          var warningMsg = `Some images exceeded the max image upload size: [${errImages.join(', ')}]`;
           return $timeout(function() { Alert.warning(warningMsg); });
         }
         // append a policy on to each image

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -117,7 +117,7 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
               if ($scope.onDone) { $scope.onDone({data: url}); }
               if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { $scope.model = url; }
               else { $scope.images.push(image); }
-              if (warningMsg) { Alert.warning(warningMsg); }
+              if (errImages.length) { Alert.warning(warningMsg); }
             })
             .catch(function(err) {
               image.progress = '--';

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -82,8 +82,9 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
           }
         });
 
+        var warningMsg = 'Some images exceeded the max image upload size: [' + errImages.join(', ') + ']';
+
         if (!$scope.currentImages.length) {
-          var warningMsg = 'Some images exceeded the max image upload size: [' + errImages.join(', ') + ']';
           return $timeout(function() { Alert.warning(warningMsg); });
         }
         // append a policy on to each image

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -83,7 +83,7 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
         });
 
         if (errImages.length) {
-          var warningMsg = `Some images exceeded the max image upload size: [${errImages.join(', ')}]`;
+          var warningMsg = 'Some images exceeded the max image upload size: [' + errImages.join(', ') + ']';
           return $timeout(function() { Alert.warning(warningMsg); });
         }
         // append a policy on to each image

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -75,11 +75,11 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
             status: 'Initializing',
             progress: 0
           };
-          if (fsImage.size < maxImageSize) {
-            $scope.currentImages.push(image);
+          if (fsImage.size > maxImageSize) {
+            errImages.push(fsImage.name);
           }
           else {
-            errImages.push(fsImage.name);
+            $scope.currentImages.push(image);
           }
         });
 

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -65,16 +65,30 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
          *   url: {string} The url where the image is hosted (upon upload completion)
          */
          // prep each image
+        var warningMsg = 'Some images exceeded the max image upload size: ';
+        var errImages = [];
         fsImages.forEach(function(fsImage) {
+          var maxImageSize = forumData.max_image_size;
           var image = {
             name: fsImage.name,
             file: fsImage,
             status: 'Initializing',
             progress: 0
           };
-          $scope.currentImages.push(image);
+          if (fsImage.size < maxImageSize) {
+            $scope.currentImages.push(image);
+          }
+          else {
+            errImages.push(fsImage.name);
+          }
         });
 
+        // CALCULATE WARNING MESSAGE HERE ITERATE THROUGH errIMAGES
+
+
+        if (!$scope.currentImages.length) {
+          return $timeout(function() { Alert.warning(warningMsg); });
+        }
         // append a policy on to each image
         return s3ImageUpload.policy($scope.currentImages)
         // upload each image
@@ -105,6 +119,7 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
               if ($scope.onDone) { $scope.onDone({data: url}); }
               if ($scope.purpose === 'avatar' || $scope.purpose === 'logo' || $scope.purpose === 'favicon') { $scope.model = url; }
               else { $scope.images.push(image); }
+              if (warningMsg) { Alert.warning(warningMsg); }
             })
             .catch(function(err) {
               image.progress = '--';

--- a/modules/ept-posts/routes/meta-byThread.js
+++ b/modules/ept-posts/routes/meta-byThread.js
@@ -43,6 +43,7 @@ module.exports = {
       favicon: config.website.favicon,
       websocket_host: config.websocket_client_host,
       websocket_port: config.websocket_port,
+      max_image_size: config.images.maxSize,
       portal: { enabled: config.portal.enabled },
       GAKey: config.gaKey,
       currentYear: new Date().getFullYear()

--- a/modules/ept-threads/routes/meta-byBoard.js
+++ b/modules/ept-threads/routes/meta-byBoard.js
@@ -40,6 +40,7 @@ module.exports = {
       favicon: config.website.favicon,
       websocket_host: config.websocket_client_host,
       websocket_port: config.websocket_port,
+      max_image_size: config.images.maxSize,
       portal: { enabled: config.portal.enabled },
       GAKey: config.gaKey,
       currentYear: new Date().getFullYear()

--- a/modules/ept-users/routes/meta-find.js
+++ b/modules/ept-users/routes/meta-find.js
@@ -55,6 +55,7 @@ module.exports = {
       favicon: config.website.favicon,
       websocket_host: config.websocket_client_host,
       websocket_port: config.websocket_port,
+      max_image_size: config.images.maxSize,
       portal: { enabled: config.portal.enabled },
       GAKey: config.gaKey,
       currentYear: new Date().getFullYear()

--- a/public/index.html
+++ b/public/index.html
@@ -131,15 +131,16 @@
       </div>
     </div>
   </noscript>
-
   <!-- Load App Bundle -->
   <script type="text/javascript" async>
+
     var forumData = {
       favicon: '{{favicon}}',
       title: '{{title}}',
       logo: '{{logo}}',
       websocket_host: '{{websocket_host}}',
       websocket_port: '{{websocket_port}}',
+      max_image_size: {{max_image_size}},
       portal: {
         enabled: {{portal.enabled}}
       }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -62,6 +62,7 @@ exports.endpoints = function(internalConfig) {
           favicon: config.website.favicon,
           websocket_host: config.websocket_client_host,
           websocket_port: config.websocket_port,
+          max_image_size: internalConfig.images.maxSize,
           portal: { enabled: config.portal.enabled },
           GAKey: config.gaKey,
           currentYear: new Date().getFullYear()


### PR DESCRIPTION
resolves #65

check if the image(s) a user is attempting to upload exceed the max file size before attempting to upload them.

the image uploader would previously try to upload images which were too big, using up time and bandwidth, and simply cause an error when the upload failed.