### PR TITLE
Use relative paths for locally host images

### DIFF
--- a/modules/ept-bbcode-parser/client/bbcode.js
+++ b/modules/ept-bbcode-parser/client/bbcode.js
@@ -42,6 +42,7 @@ var XBBCODE = (function () {
     // -----------------------------------------------------------------------------
 
     var me = {},
+        imgPattern = /^((?:https?|file|c):(?:\/{1,3}|\\{1})|\/)[-a-zA-Z0-9:;@#%&()~_?\+=\/\\\.]*$/,
         urlPattern = /^(?:https?|file|c):(?:\/{1,3}|\\{1})[-a-zA-Z0-9:;@#%&()~_?\+=\/\\\.]*$/,
         ftpPattern = /^(?:ftps?|c):(?:\/{1,3}|\\{1})[-a-zA-Z0-9:;@#%&()~_?\+=\/\\\.]*$/,
         colorCodePattern = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/,
@@ -303,8 +304,8 @@ var XBBCODE = (function () {
                 // url
                 var myUrl = content;
                 myUrl = myUrl.trim();
-                urlPattern.lastIndex = 0;
-                if (!urlPattern.test(myUrl)) {
+                imgPattern.lastIndex = 0;
+                if (!imgPattern.test(myUrl)) {
                     myUrl = "";
                 }
                 if (!params) {

--- a/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
+++ b/modules/ept-frontend/client/components/image_uploader/image_uploader.directive.js
@@ -158,13 +158,13 @@ var directive = ['$timeout', 'S3ImageUpload', 'Alert', function($timeout, s3Imag
         else {
           $scope.imagesProgressSum = $scope.imagesProgressSum - $scope.currentImages[index].progress;
           $scope.currentImages[index].progress = '--';
-          image.status = 'Failed';
+          $scope.currentImages[index].status = 'Failed';
           $scope.uploadingImages--;
         }
 
         $scope.imagesProgress = $scope.imagesProgressSum / $scope.currentImages.length + '%';
 
-        if (!($scope.uploadingImages > 0)) {
+        if ($scope.uploadingImages <= 0) {
           $scope.imagesUploading = false;
         }
       }

--- a/server/index.js
+++ b/server/index.js
@@ -195,10 +195,8 @@ setup()
       configClone.emailer.ses.secretKey = configClone.emailer.ses.secretKey.replace(/./g, '*');
     }
     if (configClone.emailer.pass) { configClone.emailer.pass = configClone.emailer.pass.replace(/./g, '*'); }
-    if (configClone.images.storage === 's3') {
-      configClone.images.s3.accessKey = configClone.images.s3.accessKey.replace(/./g, '*');
-      configClone.images.s3.secretKey = configClone.images.s3.secretKey.replace(/./g, '*');
-    }
+    if (configClone.images.s3.accessKey) { configClone.images.s3.accessKey = configClone.images.s3.accessKey.replace(/./g, '*'); }
+    if (configClone.images.s3.secretKey) { configClone.images.s3.secretKey = configClone.images.s3.secretKey.replace(/./g, '*'); }
     server.log('debug', 'DB Connection: ' + process.env.DATABASE_URL);
     server.log('debug', 'config: ' + JSON.stringify(configClone, undefined, 2));
     server.log('info', 'Epochtalk Frontend server started @' + server.info.uri);

--- a/server/index.js
+++ b/server/index.js
@@ -195,8 +195,10 @@ setup()
       configClone.emailer.ses.secretKey = configClone.emailer.ses.secretKey.replace(/./g, '*');
     }
     if (configClone.emailer.pass) { configClone.emailer.pass = configClone.emailer.pass.replace(/./g, '*'); }
-    configClone.images.s3.accessKey = configClone.images.s3.accessKey.replace(/./g, '*');
-    configClone.images.s3.secretKey = configClone.images.s3.secretKey.replace(/./g, '*');
+    if (configClone.images.storage === 's3') {
+      configClone.images.s3.accessKey = configClone.images.s3.accessKey.replace(/./g, '*');
+      configClone.images.s3.secretKey = configClone.images.s3.secretKey.replace(/./g, '*');
+    }
     server.log('debug', 'DB Connection: ' + process.env.DATABASE_URL);
     server.log('debug', 'config: ' + JSON.stringify(configClone, undefined, 2));
     server.log('info', 'Epochtalk Frontend server started @' + server.info.uri);

--- a/server/plugins/imageStore/local.js
+++ b/server/plugins/imageStore/local.js
@@ -49,7 +49,7 @@ local.uploadPolicy = function(filename) {
 local.saveImage = function(imgSrc) {
   // image uploaded by client
   var url;
-  if (imgSrc.indexOf(config.publicUrl) === 0) {
+  if (imgSrc.indexOf(config.publicUrl) === 0 || imgSrc.indexOf(config.images.local.path) === 0) {
     // clear any expirations
     imageStore.clearExpiration(imgSrc);
   }
@@ -64,8 +64,7 @@ local.saveImage = function(imgSrc) {
 };
 
 var generateImageUrl = function(filename) {
-  var imageUrl = config.publicUrl;
-  imageUrl += config.images.local.path + filename;
+  var imageUrl = config.images.local.path + filename;
   return imageUrl;
 };
 


### PR DESCRIPTION
Uploading locally hosted images should now use relative paths instead of a full local path including  the PUBLIC_URL variable. 

Please test locally @unenglishable 👍 

Feel free to test @hipio, this should resolve #190. 

* Prior to this commit the PUBLIC_URL config was referenced when
  loading images which were uploaded locally. This commit resolves
  this issue and uses a relative path to the image instead of a
  full direct path, which will break if PUBLIC_URL changes.