### PR TITLE
Fix for thread no loading when using the back button

### DIFF
--- a/modules/ept-frontend/client/posts/index.js
+++ b/modules/ept-frontend/client/posts/index.js
@@ -48,14 +48,23 @@ var route = ['$stateProvider', function($stateProvider) {
         });
         return deferred.promise;
       }],
-      pageData: ['Posts', 'Threads', 'PreferencesSvc', '$stateParams', function(Posts, Threads, PreferencesSvc, $stateParams) {
+      pageData: ['Posts', 'Threads', 'PreferencesSvc', '$stateParams', '$location', function(Posts, Threads, PreferencesSvc, $stateParams, $location) {
+
+        // If start is present page should not be present
+        if ($stateParams.start && $stateParams.page) {
+          delete $stateParams.page;
+          $location.search('page', undefined);
+        }
+
         var pref = PreferencesSvc.preferences;
+
         var query = {
           thread_id: $stateParams.threadId,
           page: $stateParams.page,
           limit: $stateParams.limit || pref.posts_per_page || 25,
           start: $stateParams.start
         };
+
         Threads.viewed({ id: $stateParams.threadId });
         return Posts.byThread(query).$promise;
       }]


### PR DESCRIPTION
* Sometimes when using the back button the thread will throw an error
  and not load. This was because both "start" and "page" query
  parameters were present and the route does not allow for both
  of these to be present.

* If start and page are present in the post view resolve, the
  page query parameter is removed.