### PR TITLE
Test db

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 7

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
 machine:
   node:
     version: 7
+  environment:
+    DATABASE_URL: postgres://localhost/epoch_test
+    TEST_DATABASE_URL: postgres://localhost/epoch_test

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "sass": "node ./scripts/sass.js",
     "build": "node ./scripts/build.js",
     "serve": "node ./scripts/serve.js",
-    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-threads && npm run test-notifications",
+    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-threads && npm run test-posts && npm run test-notifications",
     "test-notifications": "./node_modules/.bin/lab test/notifications.js --flat -v",
     "test-categories": "./node_modules/.bin/lab test/categories.js --flat -v",
     "test-boards": "./node_modules/.bin/lab test/boards.js --flat -v",
     "test-threads": "./node_modules/.bin/lab test/threads.js --flat -v",
+    "test-posts": "./node_modules/.bin/lab test/posts.js --flat -v",
     "start": "npm run db-migrate && ./node_modules/.bin/bower install && npm run build && node cli/index.js --create && node server"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "sass": "node ./scripts/sass.js",
     "build": "node ./scripts/build.js",
     "serve": "node ./scripts/serve.js",
-    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards",
+    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-notifications",
+    "test-notifications": "./node_modules/.bin/lab test/notifications.js --flat -v",
     "test-categories": "./node_modules/.bin/lab test/categories.js --flat -v",
     "test-boards": "./node_modules/.bin/lab test/boards.js --flat -v",
     "start": "npm run db-migrate && ./node_modules/.bin/bower install && npm run build && node cli/index.js --create && node server"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "sass": "node ./scripts/sass.js",
     "build": "node ./scripts/build.js",
     "serve": "node ./scripts/serve.js",
-    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-notifications",
+    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-threads && npm run test-notifications",
     "test-notifications": "./node_modules/.bin/lab test/notifications.js --flat -v",
     "test-categories": "./node_modules/.bin/lab test/categories.js --flat -v",
     "test-boards": "./node_modules/.bin/lab test/boards.js --flat -v",
+    "test-threads": "./node_modules/.bin/lab test/threads.js --flat -v",
     "start": "npm run db-migrate && ./node_modules/.bin/bower install && npm run build && node cli/index.js --create && node server"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
     "webpack": "^1.12.2"
   },
   "devDependencies": {
+    "brototype": "0.0.6",
+    "code": "^4.0.0",
+    "faker": "^4.1.0",
+    "lab": "^13.0.1",
     "livereload": "^0.4.0",
     "mocha": "^2.4.1",
     "nodemon": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "sass": "node ./scripts/sass.js",
     "build": "node ./scripts/build.js",
     "serve": "node ./scripts/serve.js",
-    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-threads && npm run test-posts && npm run test-notifications",
+    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards && npm run test-threads && npm run test-posts && npm run test-notifications && npm run test-users",
     "test-notifications": "./node_modules/.bin/lab test/notifications.js --flat -v",
     "test-categories": "./node_modules/.bin/lab test/categories.js --flat -v",
     "test-boards": "./node_modules/.bin/lab test/boards.js --flat -v",
     "test-threads": "./node_modules/.bin/lab test/threads.js --flat -v",
     "test-posts": "./node_modules/.bin/lab test/posts.js --flat -v",
+    "test-users": "./node_modules/.bin/lab test/users.js --flat -v",
     "start": "npm run db-migrate && ./node_modules/.bin/bower install && npm run build && node cli/index.js --create && node server"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "node ./scripts/build.js",
     "serve": "node ./scripts/serve.js",
     "test": "./node_modules/.bin/mocha -R spec ./tests",
+    "test-categories": "./node_modules/.bin/lab test/categories.js --flat -v",
+    "test-boards": "./node_modules/.bin/lab test/boards.js --flat -v",
     "start": "npm run db-migrate && ./node_modules/.bin/bower install && npm run build && node cli/index.js --create && node server"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sass": "node ./scripts/sass.js",
     "build": "node ./scripts/build.js",
     "serve": "node ./scripts/serve.js",
-    "test": "./node_modules/.bin/mocha -R spec ./tests",
+    "test": "./node_modules/.bin/mocha -R spec ./tests && dropdb --if-exists epoch_test && createdb epoch_test && DATABASE_URL=postgres://localhost/epoch_test npm run db-migrate && npm run test-categories && npm run test-boards",
     "test-categories": "./node_modules/.bin/lab test/categories.js --flat -v",
     "test-boards": "./node_modules/.bin/lab test/boards.js --flat -v",
     "start": "npm run db-migrate && ./node_modules/.bin/bower install && npm run build && node cli/index.js --create && node server"

--- a/test/boards.js
+++ b/test/boards.js
@@ -17,7 +17,7 @@ lab.experiment('Boards', function() {
     expect(board.id).to.equal(seededBoard.id);
   };
   lab.before({timeout: 5000}, function(done) {
-    return seed(fixture)
+    seed(fixture)
     .then(function(results) {
       runtime = results;
     })
@@ -50,7 +50,7 @@ lab.experiment('Boards', function() {
     });
   });
   lab.test('should fail to find a board by invalid id', function(done) {
-    return db.boards.find()
+    db.boards.find()
     .then(function(board) {
       throw new Error('Should not have found a board');
     })

--- a/test/boards.js
+++ b/test/boards.js
@@ -6,6 +6,7 @@ var Promise = require('bluebird');
 var db = require(path.join(__dirname, 'db'));
 var seed = require(path.join(__dirname, 'seed', 'populate'));
 var fixture = require(path.join(__dirname, 'fixtures', 'boards'));
+var clean = require(path.join(__dirname, 'seed', 'clean'));
 var NotFoundError = Promise.OperationalError;
 
 lab.experiment('Boards', function() {
@@ -57,6 +58,11 @@ lab.experiment('Boards', function() {
     .catch(function(err) {
       expect(err).to.be.an.instanceof(NotFoundError);
       expect(err.cause).to.be.a.string().and.to.equal('Board Not Found');
+      done();
+    });
+  });
+  lab.after(function(done) {
+    clean().then(function() {
       done();
     });
   });

--- a/test/boards.js
+++ b/test/boards.js
@@ -1,0 +1,63 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, 'db'));
+var seed = require(path.join(__dirname, 'seed', 'populate'));
+var fixture = require(path.join(__dirname, 'fixtures', 'boards'));
+var NotFoundError = Promise.OperationalError;
+
+lab.experiment('Boards', function() {
+  var runtime;
+  var expectations = function(seededBoard, board) {
+    expect(board).to.exist;
+    expect(board.name).to.equal(seededBoard.name);
+    expect(board.description).to.equal(seededBoard.description);
+    expect(board.id).to.equal(seededBoard.id);
+  };
+  lab.before({timeout: 5000}, function(done) {
+    return seed(fixture)
+    .then(function(results) {
+      runtime = results;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return all boards', function(done) {
+    db.boards.all()
+    .then(function(boards) {
+      expect(boards).to.be.an.array();
+      expect(boards).to.have.length(runtime.boards.length);
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should find a board by id', function(done) {
+    Promise.map(runtime.boards, function(seededBoard) {
+      return db.boards.find(seededBoard.id)
+      .then(function(board) {
+        expectations(seededBoard, board);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should fail to find a board by invalid id', function(done) {
+    return db.boards.find()
+    .then(function(board) {
+      throw new Error('Should not have found a board');
+    })
+    .catch(function(err) {
+      expect(err).to.be.an.instanceof(NotFoundError);
+      expect(err.cause).to.be.a.string().and.to.equal('Board Not Found');
+      done();
+    });
+  });
+});

--- a/test/categories.js
+++ b/test/categories.js
@@ -6,6 +6,7 @@ var Promise = require('bluebird');
 var db = require(path.join(__dirname, 'db'));
 var seed = require(path.join(__dirname, 'seed', 'populate'));
 var fixture = require(path.join(__dirname, 'fixtures', 'categories'));
+var clean = require(path.join(__dirname, 'seed', 'clean'));
 var NotFoundError = Promise.OperationalError;
 
 lab.experiment('Categories', function() {
@@ -44,6 +45,11 @@ lab.experiment('Categories', function() {
     .catch(function(err) {
       expect(err).to.be.an.instanceof(NotFoundError);
       expect(err.cause).to.be.a.string().and.to.equal('Category Not Found');
+      done();
+    });
+  });
+  lab.after(function(done) {
+    clean().then(function() {
       done();
     });
   });

--- a/test/categories.js
+++ b/test/categories.js
@@ -1,0 +1,51 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, 'db'));
+var seed = require(path.join(__dirname, 'seed', 'populate'));
+var fixture = require(path.join(__dirname, 'fixtures', 'categories'));
+var NotFoundError = Promise.OperationalError;
+
+lab.experiment('Categories', function() {
+  var runtime;
+  var expectations = function(seededCategory, category) {
+    expect(category).to.exist;
+    expect(category.id).to.equal(seededCategory.id);
+    expect(category.name).to.equal(seededCategory.name);
+  };
+  lab.before(function(done) {
+    return seed(fixture)
+    .tap('here')
+    .then(function(results) { runtime = results; })
+    .then(function() { done(); });
+  });
+  lab.test('should return all categories', function(done) {
+    db.categories.all(function(categories) {
+      expect(categories).to.be.an.array();
+      expect(categories).to.have.length(runtime.categories.length);
+    })
+    .then(function() { done(); });
+  });
+  lab.test('should find a category by id', function(done) {
+    Promise.map(runtime.categories, function(seededCategory) {
+      return db.categories.find(seededCategory.id).then(function(category) {
+        expectations(seededCategory, category);
+      })
+      .catch(function(err) { throw err; });
+    })
+    .then(function() { done(); });
+  });
+  lab.test('should fail to find a category by invalid id', function(done) {
+    db.categories.find()
+    .then(function() {
+      throw new Error('Should not have found a category');
+    })
+    .catch(function(err) {
+      expect(err).to.be.an.instanceof(NotFoundError);
+      expect(err.cause).to.be.a.string().and.to.equal('Category Not Found');
+      done();
+    });
+  });
+});

--- a/test/categories.js
+++ b/test/categories.js
@@ -16,8 +16,7 @@ lab.experiment('Categories', function() {
     expect(category.name).to.equal(seededCategory.name);
   };
   lab.before(function(done) {
-    return seed(fixture)
-    .tap('here')
+    seed(fixture)
     .then(function(results) { runtime = results; })
     .then(function() { done(); });
   });

--- a/test/categories.js
+++ b/test/categories.js
@@ -21,7 +21,7 @@ lab.experiment('Categories', function() {
     .then(function() { done(); });
   });
   lab.test('should return all categories', function(done) {
-    db.categories.all(function(categories) {
+    db.categories.all().then(function(categories) {
       expect(categories).to.be.an.array();
       expect(categories).to.have.length(runtime.categories.length);
     })

--- a/test/db.js
+++ b/test/db.js
@@ -1,0 +1,5 @@
+var path = require('path');
+module.exports = {
+  categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,
+  boards: require(path.normalize(__dirname + '/../modules/ept-boards')).db
+};

--- a/test/db.js
+++ b/test/db.js
@@ -1,3 +1,5 @@
 var path = require('path');
-var core = require(path.join(__dirname, '..'));
-module.exports = core({ conString: 'epoch_test' });
+module.exports = {
+  categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,
+  boards: require(path.normalize(__dirname + '/../modules/ept-boards')).db
+};

--- a/test/db.js
+++ b/test/db.js
@@ -6,5 +6,7 @@ module.exports = {
   notifications: core.notifications,
   users: require(path.normalize(__dirname + '/../modules/ept-users')).db,
   categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,
-  boards: require(path.normalize(__dirname + '/../modules/ept-boards')).db
+  boards: require(path.normalize(__dirname + '/../modules/ept-boards')).db,
+  threads: require(path.normalize(__dirname + '/../modules/ept-threads')).db,
+  posts: require(path.normalize(__dirname + '/../modules/ept-posts')).db
 };

--- a/test/db.js
+++ b/test/db.js
@@ -1,7 +1,10 @@
 require('dotenv').load();
 process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
 var path = require('path');
+var core = require('epochtalk-core-pg')({ conString: process.env.DATABASE_URL });
 module.exports = {
+  notifications: core.notifications,
+  users: require(path.normalize(__dirname + '/../modules/ept-users')).db,
   categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,
   boards: require(path.normalize(__dirname + '/../modules/ept-boards')).db
 };

--- a/test/db.js
+++ b/test/db.js
@@ -1,3 +1,4 @@
+require('dotenv').load();
 var path = require('path');
 module.exports = {
   categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,

--- a/test/db.js
+++ b/test/db.js
@@ -1,4 +1,5 @@
 require('dotenv').load();
+process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
 var path = require('path');
 module.exports = {
   categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,

--- a/test/db.js
+++ b/test/db.js
@@ -1,5 +1,3 @@
 var path = require('path');
-module.exports = {
-  categories: require(path.normalize(__dirname + '/../modules/ept-categories')).db,
-  boards: require(path.normalize(__dirname + '/../modules/ept-boards')).db
-};
+var core = require(path.join(__dirname, '..'));
+module.exports = core({ conString: 'epoch_test' });

--- a/test/db.js
+++ b/test/db.js
@@ -1,4 +1,4 @@
-require('dotenv').load();
+require('dotenv').load({ silent: true });
 process.env.DATABASE_URL = process.env.TEST_DATABASE_URL;
 var path = require('path');
 var core = require('epochtalk-core-pg')({ conString: process.env.DATABASE_URL });

--- a/test/fixtures/boards.js
+++ b/test/fixtures/boards.js
@@ -1,0 +1,30 @@
+var path = require('path');
+var fake = require(path.join(__dirname, '..', 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0'
+module.exports = {
+  run: [
+    'categories',
+    'boards'
+  ],
+  methods: {
+    categories: fake.categories,
+    boards: fake.boards
+  },
+  data: {
+    categories: [
+      {},
+      {},
+      {},
+      {}
+    ],
+    boards: [
+      {}, // has children boards.1,2,3
+      {},
+      {},
+      {},
+      {}
+    ]
+  }
+};

--- a/test/fixtures/categories.js
+++ b/test/fixtures/categories.js
@@ -1,0 +1,21 @@
+var path = require('path');
+var fake = require(path.join(__dirname, '..', 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0'
+module.exports = {
+  run: [
+    'categories'
+  ],
+  methods: {
+    categories : fake.categories
+  },
+  data: {
+    categories: [
+      {},
+      {},
+      {},
+      {}
+    ]
+  }
+};

--- a/test/fixtures/notifications.js
+++ b/test/fixtures/notifications.js
@@ -1,0 +1,80 @@
+var path = require('path');
+var fake = require(path.join(__dirname, '..', 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0'
+module.exports = {
+  run: [
+    'users',
+    'notifications'
+  ],
+  methods: {
+    users: fake.users,
+    notifications: fake.notifications
+  },
+  data: {
+    users: [
+      {},
+      {},
+      {},
+      {}
+    ],
+    notifications: [
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.0.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.1.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.1.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.2.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.2.id', sender_id: 'users.1.id', type: 'message' },
+      { receiver_id: 'users.2.id', sender_id: 'users.2.id', type: 'message' },
+      { receiver_id: 'users.2.id', sender_id: 'users.0.id', type: 'mention' },
+      { receiver_id: 'users.2.id', sender_id: 'users.1.id', type: 'mention' },
+      { receiver_id: 'users.2.id', sender_id: 'users.2.id', type: 'mention' },
+      { receiver_id: 'users.3.id', sender_id: 'users.0.id', type: 'message' },
+      { receiver_id: 'users.3.id', sender_id: 'users.1.id', type: 'message' }
+    ]
+  }
+};

--- a/test/fixtures/posts.js
+++ b/test/fixtures/posts.js
@@ -1,0 +1,66 @@
+var path = require('path');
+var fake = require(path.join(__dirname, '..', 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0'
+module.exports = {
+  run: [
+    'users',
+    'categories',
+    'boards',
+    'threads',
+    'posts'
+  ],
+  methods: {
+    users: fake.users,
+    categories: fake.categories,
+    boards: fake.boards,
+    threads: fake.threads,
+    posts: fake.posts
+  },
+  data: {
+    users: [
+      {},
+      {},
+      {},
+      {}
+    ],
+    categories: [
+      {},
+      {},
+      {},
+      {}
+    ],
+    boards: [
+      {},
+      {},
+      {},
+      {},
+      {}
+    ],
+    threads: [
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' }
+    ],
+    posts: [
+      { thread_id: 'threads.0.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.1.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.2.id', user_id: 'users.1.id' },
+      { thread_id: 'threads.3.id', user_id: 'users.2.id' },
+      { thread_id: 'threads.4.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.5.id', user_id: 'users.1.id' },
+      { thread_id: 'threads.6.id', user_id: 'users.2.id' },
+      { thread_id: 'threads.7.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.8.id', user_id: 'users.1.id' }
+    ]
+  }
+};

--- a/test/fixtures/threads.js
+++ b/test/fixtures/threads.js
@@ -8,15 +8,23 @@ module.exports = {
     'users',
     'categories',
     'boards',
-    'threads'
+    'threads',
+    'posts'
   ],
   methods: {
     users: fake.users,
     categories: fake.categories,
     boards: fake.boards,
-    threads: fake.threads
+    threads: fake.threads,
+    posts: fake.posts
   },
   data: {
+    users: [
+      {},
+      {},
+      {},
+      {}
+    ],
     categories: [
       {},
       {},
@@ -40,6 +48,19 @@ module.exports = {
       { board_id: 'boards.2.id' },
       { board_id: 'boards.2.id' },
       { board_id: 'boards.2.id' }
+    ],
+    posts: [
+      { thread_id: 'threads.0.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.0.id', user_id: 'users.1.id' },
+      { thread_id: 'threads.0.id', user_id: 'users.2.id' },
+      { thread_id: 'threads.1.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.2.id', user_id: 'users.1.id' },
+      { thread_id: 'threads.3.id', user_id: 'users.2.id' },
+      { thread_id: 'threads.4.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.5.id', user_id: 'users.1.id' },
+      { thread_id: 'threads.6.id', user_id: 'users.2.id' },
+      { thread_id: 'threads.7.id', user_id: 'users.0.id' },
+      { thread_id: 'threads.8.id', user_id: 'users.1.id' }
     ]
   }
 };

--- a/test/fixtures/threads.js
+++ b/test/fixtures/threads.js
@@ -1,0 +1,45 @@
+var path = require('path');
+var fake = require(path.join(__dirname, '..', 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0'
+module.exports = {
+  run: [
+    'users',
+    'categories',
+    'boards',
+    'threads'
+  ],
+  methods: {
+    users: fake.users,
+    categories: fake.categories,
+    boards: fake.boards,
+    threads: fake.threads
+  },
+  data: {
+    categories: [
+      {},
+      {},
+      {},
+      {}
+    ],
+    boards: [
+      {}, // has children boards.1,2,3
+      {},
+      {},
+      {},
+      {}
+    ],
+    threads: [
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' }
+    ]
+  }
+};

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -1,0 +1,21 @@
+var path = require('path');
+var fake = require(path.join(__dirname, '..', 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0'
+module.exports = {
+  run: [
+    'users'
+  ],
+  methods: {
+    users: fake.users
+  },
+  data: {
+    users: [
+      {},
+      {},
+      {},
+      {}
+    ]
+  }
+};

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -1,0 +1,321 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, 'db'));
+var seed = require(path.join(__dirname, 'seed', 'populate'));
+var fixture = require(path.join(__dirname, 'fixtures', 'notifications'));
+var clean = require(path.join(__dirname, 'seed', 'clean'));
+var NotFoundError = Promise.OperationalError;
+var CreationError = Promise.OperationalError;
+
+lab.experiment('Notifications', function() {
+  var runtime;
+  lab.before({timeout: 5000}, function(done) {
+    seed(fixture)
+    .then(function(results) {
+      runtime = results;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should create a notification for a user', function(done) {
+    db.notifications.create({ sender_id: runtime.users[3].id, receiver_id: runtime.users[3].id, type: 'test' })
+    .then(function(notification) {
+      expect(notification).to.exist;
+      expect(notification.id).to.exist;
+      expect(notification.created_at).to.be.a.date();
+      expect(notification.viewed).to.be.false();
+    })
+    .then(function() {
+      done();
+    })
+    .catch(function(err) {
+      throw err;
+    });
+  });
+  lab.test('should not create a notification for invalid sender_id', function(done) {
+    Promise.resolve().then(function() {
+      db.notifications.create({ sender_id: 'garbage_id', receiver_id: runtime.users[3].id, type: 'test' })
+      .catch(function(err) {
+        expect(err).to.be.instanceof(CreationError);
+      });
+    })
+    .then(done);
+  });
+  lab.test('should not create a notification for invalid receiver_id', function(done) {
+    Promise.resolve().then(function() {
+      db.notifications.create({ sender_id: runtime.users[3].id, receiver_id: 'garbage_id', type: 'test' })
+      .catch(function(err) {
+        expect(err).to.be.instanceof(CreationError);
+      });
+    })
+    .then(done);
+  });
+  lab.test('should not create a notification without type', function(done) {
+    Promise.resolve().then(function() {
+      db.notifications.create({ sender_id: runtime.users[3].id, receiver_id: runtime.users[3].id })
+      .catch(function(err) {
+        expect(err).to.be.instanceof(CreationError);
+      });
+    })
+    .then(done);
+  });
+  lab.test('should not create a notification without options', function(done) {
+    Promise.resolve().then(function() {
+      db.notifications.create()
+      .catch(function(err) {
+        expect(err).to.be.instanceof(CreationError);
+      });
+    })
+    .then(done);
+  });
+  lab.test('should return message notifications for a user', function(done) {
+    Promise.map(runtime.users, function(user) {
+      return db.notifications.latest(user.id, { type: 'message' })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return mention notifications for a user', function(done) {
+    Promise.map(runtime.users, function(user) {
+      return db.notifications.latest(user.id, { type: 'mention' })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return default paged message notifications for a user', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      // this is the default paging limit
+      return db.notifications.latest(user.id, { type: 'message' })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(15);
+      })
+      .then(function() {
+        // this is the first page of notifications
+        return db.notifications.latest(user.id, { type: 'message', page: 1 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(15);
+      })
+      .then(function() {
+        // this is the second page of notifications
+        return db.notifications.latest(user.id, { type: 'message', page: 2 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(3);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return default paged mention notifications for a user', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      // this is the default paging limit
+      return db.notifications.latest(user.id, { type: 'mention' })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(15);
+      })
+      .then(function() {
+        // this is the first page of notifications
+        return db.notifications.latest(user.id, { type: 'mention', page: 1 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(15);
+      })
+      .then(function() {
+        // this is the second page of notifications
+        return db.notifications.latest(user.id, { type: 'mention', page: 2 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(3);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should not return notifications for a user for empty page', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      // this is the default paging limit
+      return db.notifications.latest(user.id, { type: 'message', page: 3 })
+      .then(function(notifications) {
+        expect(notifications).to.not.exist;
+        expect(notifications).to.have.length(0);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return limited paged notifications for a user', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      // this is the default paging limit
+      return db.notifications.latest(user.id, { type: 'message', limit: 1 })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(1);
+      })
+      .then(function() {
+        return db.notifications.latest(user.id, { type: 'message', limit: 10, page: 2 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(8);
+      })
+      .then(function() {
+        return db.notifications.latest(user.id, { type: 'message', limit: 20 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.exist;
+        expect(notifications).to.have.length(18);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should not return notifications for empty limited page', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      // this is the default paging limit
+      return db.notifications.latest(user.id, { type: 'message', limit: 20, page: 2 })
+      .then(function(notifications) {
+        expect(notifications).to.not.exist;
+        expect(notifications).to.have.length(0);
+      })
+      .then(function() {
+        return db.notifications.latest(user.id, { type: 'message', limit: 1, page: 19 });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.not.exist;
+        expect(notifications).to.have.length(0);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return user notifications counts', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      return db.notifications.counts(user.id)
+      .then(function(counts) {
+        expect(counts.message).to.exist;
+        expect(counts.message).to.equal('10+');
+        expect(counts.mention).to.exist;
+        expect(counts.mention).to.equal('10+');
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      return runtime.users[1];
+    })
+    .then(function(user) {
+      return db.notifications.counts(user.id)
+      .then(function(counts) {
+        expect(counts.message).to.exist;
+        expect(counts.message).to.equal('10+');
+        expect(counts.mention).to.not.exist;
+        expect(counts.mention).to.equal(0);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      return runtime.users[2];
+    })
+    .then(function(user) {
+      return db.notifications.counts(user.id)
+      .then(function(counts) {
+        expect(counts.message).to.exist;
+        expect(counts.message).to.equal(3);
+        expect(counts.mention).to.exist;
+        expect(counts.mention).to.equal(3);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should dismiss notifications', function(done) {
+    Promise.resolve(runtime.users[0]).then(function(user) {
+      // this is the default paging limit
+      return db.notifications.dismiss({ receiver_id: user.id, type: 'message' })
+      .then(function() { return db.notifications.counts(user.id); })
+      .then(function(counts) {
+        expect(counts.message).to.equal(0);
+        expect(counts.mention).to.equal('10+');
+      })
+      .then(function() { return db.notifications.counts(runtime.users[1].id); })
+      .then(function(counts) {
+        expect(counts.message).to.equal('10+');
+      })
+      .then(function() {
+        return db.notifications.latest(user.id, { type: 'message' });
+      })
+      .then(function(notifications) {
+        expect(notifications).to.have.length(0);
+      })
+      .then(function(notifications) {
+        return db.notifications.dismiss({ receiver_id: user.id, type: 'message' })
+        .catch(function(err) {
+          expect(err).to.not.exist();
+        });
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.after(function(done) {
+    clean().then(function() {
+      done();
+    });
+  });
+});

--- a/test/posts.js
+++ b/test/posts.js
@@ -1,0 +1,127 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, 'db'));
+var seed = require(path.join(__dirname, 'seed', 'populate'));
+var fixture = require(path.join(__dirname, 'fixtures', 'posts'));
+var NotFoundError = Promise.OperationalError;
+
+lab.experiment('Posts', function() {
+  var runtime;
+  var expectations = function(seededPost, post) {
+    expect(post).to.exist;
+    expect(post.thread_id).to.equal(seededPost.thread_id);
+    expect(post.id).to.equal(seededPost.id);
+  };
+  lab.before({timeout: 5000}, function(done) {
+    return seed(fixture)
+    .then(function(results) {
+      runtime = results;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should find a post by id', function(done) {
+    Promise.map(runtime.posts, function(seededPost) {
+      return db.posts.find(seededPost.id)
+      .then(function(post) {
+        expectations(seededPost, post);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should fail to find a post by invalid id', function(done) {
+    return db.posts.find()
+    .then(function(post) {
+      throw new Error('Should not have found a post');
+    })
+    .catch(function(err) {
+      expect(err).to.be.an.instanceof(NotFoundError);
+      expect(err.cause).to.be.a.string().and.to.equal('Post Not Found');
+      done();
+    });
+  });
+  lab.test('should find posts by thread', function(done) {
+    return Promise.map(runtime.posts, function(seededPost) {
+      return db.posts.byThread(seededPost.thread_id)
+      .then(function(posts) {
+        expect(posts.length).to.equal(1);
+        expectations(seededPost, posts[0]);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should not find posts by thread', function(done) {
+    return db.posts.byThread(runtime.threads[10].id)
+    .then(function(posts) {
+      expect(posts).to.be.an.array();
+      expect(posts).to.have.length(0);
+    })
+    .catch(function() {
+      throw err;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return no posts for an invalid thread', function(done) {
+    return db.posts.byThread()
+    .then(function(posts) {
+      expect(posts).to.be.an.array();
+      expect(posts).to.have.length(0);
+    })
+    .catch(function(err) {
+      throw err;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should increment thread\'s post count', function(done) {
+    return Promise.map(runtime.threads.slice(0, 9), function(seededThread) {
+      return db.threads.find(seededThread.id)
+      .then(function(thread) {
+        expect(thread.post_count).to.equal(1);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should update boards\' posts counts', function(done) {
+    Promise.map(runtime.posts, function(seededPost) {
+      return db.posts.find(seededPost.id)
+      .then(function(post) {
+        return db.threads.find(post.thread_id);
+      })
+      .then(function(thread) {
+        return db.boards.find(thread.board_id);
+      })
+      .then(function(board) {
+        expect(board.post_count).to.equal(3);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+});

--- a/test/seed/clean.js
+++ b/test/seed/clean.js
@@ -1,0 +1,40 @@
+require('dotenv').load();
+var Promise = require('bluebird');
+var core = require('epochtalk-core-pg')({ conString: process.env.TEST_DATABASE_URL });
+var db = core.db;
+var close = core.close;
+
+// create a function to clear rows from all tables
+module.exports = function() {
+  return db.sqlQuery(`CREATE OR REPLACE FUNCTION truncate_tables(username IN VARCHAR) RETURNS void AS $$
+    DECLARE
+      statements CURSOR FOR
+        SELECT tablename FROM pg_tables
+        WHERE tableowner = username AND schemaname = 'public';
+      BEGIN
+        FOR stmt IN statements LOOP
+          EXECUTE 'TRUNCATE TABLE ' || quote_ident(stmt.tablename) || ' CASCADE;';
+        END LOOP;
+      END;
+  $$ LANGUAGE plpgsql;`)
+  .then(function() {
+    return db.scalar(`SELECT current_user`);
+  })
+  .then(function(user) {
+    // clear rows from all tables
+    console.log('Clearing rows from tables...');
+    return db.sqlQuery(`SELECT truncate_tables($1)`, [user.current_user]);
+  })
+  .then(function(nothing) {
+    // delete the function created earlier
+    return db.sqlQuery(`DROP FUNCTION truncate_tables(username VARCHAR);`);
+  })
+  .then(function() {
+    console.log('Finished clearing rows from tables!');
+    close();
+  })
+  .catch(function(error) {
+    console.error(error);
+    close();
+  });
+};

--- a/test/seed/clean.js
+++ b/test/seed/clean.js
@@ -1,4 +1,4 @@
-require('dotenv').load();
+require('dotenv').load({ silent: true });
 var Promise = require('bluebird');
 var core = require('epochtalk-core-pg')({ conString: process.env.TEST_DATABASE_URL });
 var db = core.db;

--- a/test/seed/example-fixture.js
+++ b/test/seed/example-fixture.js
@@ -1,0 +1,60 @@
+var path = require('path');
+var fake = require(path.join(__dirname, 'seed', 'fake'));
+
+// self-reference using a string
+// ex: 'users.0.id'
+module.exports = {
+  run: [
+    'categories',
+    'boards',
+    'threads'
+  ],
+  methods: {
+    categories: fake.userData,
+    boards: fake.boardData,
+    threads: fake.threadData
+  },
+  data: {
+    /*
+    * fake.categoryData();
+    */
+    categories: [
+      {},
+      {},
+      {},
+      {}
+    ],
+    /*
+    * fake.boardData({
+    *   parent_board_id: runtime.boards[currentBoard.parentBoard].id,
+    *   category_id: runtime.categories[currentBoard.category].id,
+    *   children_ids: // function for children indexes to childrens' ids
+    * });
+    */
+    boards: [
+      {},
+      {},
+      {},
+      {},
+      {},
+      {}
+    ],
+    /*
+    * fake.threadData({
+    *   board_id: runtime.boards[currentThread.board].id
+    * });
+    */
+    threads: [
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.0.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.1.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' },
+      { board_id: 'boards.2.id' },
+      {}
+    ]
+  }
+};

--- a/test/seed/fake.js
+++ b/test/seed/fake.js
@@ -1,0 +1,76 @@
+var path = require('path');
+var db = require(path.join(__dirname, '..', 'db'));
+var faker = require('faker');
+var Promise = require('bluebird');
+var fake = {};
+module.exports = fake;
+
+fake.users = function() {
+  var user = {
+    password: faker.internet.password(),
+    email: faker.internet.email(),
+    username: faker.internet.userName()
+  };
+  return Promise.resolve(user).then(db.users.create);
+};
+
+fake.categories = function() {
+  var category = {
+    name: faker.company.bsAdjective()
+  };
+  return Promise.resolve(category).then(db.categories.create)
+    .then(function(createdCategory) {
+      // return name for runtime
+      createdCategory.name = category.name;
+      return createdCategory;
+    });
+};
+
+fake.boards = function(options) {
+  var board = {
+    name: faker.company.bsNoun(),
+    description: faker.company.bsBuzz() + ' ' + faker.company.bsAdjective() + ' ' + faker.company.bsNoun()
+  };
+  return Promise.resolve(board).then(db.boards.create);
+};
+
+fake.threads = function(options) {
+  var thread = { sticky: false };
+  if (options) {
+    if (options.board_id) thread.board_id = options.board_id;
+  }
+  return Promise.resolve(thread).then(db.threads.create)
+    .then(function(createdThread) {
+      // return board_id for runtime
+      createdThread.board_id = thread.board_id;
+      return createdThread;
+    });
+};
+
+fake.posts = function(options) {
+  var body = '';
+  var length = faker.random.number(7) + 1;
+  for(var i = 0; i < length; i++) {
+    body += faker.hacker.phrase() + '\n';
+  }
+  var post = {
+    body: body,
+    raw_body: body,
+    title: faker.hacker.ingverb() + ' the ' + faker.hacker.adjective() + ' ' + faker.hacker.noun()
+  };
+  if (options) {
+    if (options.thread_id) post.thread_id = options.thread_id;
+    if (options.user_id) post.user_id = options.user_id;
+  }
+  return Promise.resolve(post).then(db.posts.create);
+};
+
+fake.notifications = function(options) {
+  var notification = {
+    type: options.type,
+    sender_id: options.sender_id,
+    receiver_id: options.receiver_id,
+    data: {}
+  };
+  return Promise.resolve(notification).then(db.notifications.create);
+}

--- a/test/seed/populate.js
+++ b/test/seed/populate.js
@@ -1,0 +1,25 @@
+var Promise = require('bluebird');
+var Bro = require('brototype');
+
+module.exports = function(fixture) {
+  var runtime = {};
+  Object.keys(fixture.data).forEach(function(dataType) {
+    runtime[dataType] = [];
+  });
+  return Promise.each(fixture.run, function(dataType) {
+    return Promise.each(fixture.data[dataType], function(options) {
+      return Promise.reduce(Object.keys(options), function(current, field) {
+        current[field] = Bro(runtime).iCanHaz(options[field]) || options[field];
+        return current;
+      }, {})
+      .then(function(options) {
+        return fixture.methods[dataType](options).then(function(result) {
+          runtime[dataType].push(result);
+        });
+      });
+    });
+  })
+  .then(function(results) {
+    return runtime;
+  });
+};

--- a/test/seed/test-fixtures.js
+++ b/test/seed/test-fixtures.js
@@ -1,0 +1,38 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var seed = require(path.join(__dirname, '..', 'seed', 'populate'));
+var fixtures = {
+  categories: require(path.join(__dirname, '..', 'fixtures', 'categories')),
+  boards: require(path.join(__dirname, '..', 'fixtures', 'boards')),
+  threads: require(path.join(__dirname, '..', 'fixtures', 'threads')),
+};
+
+lab.experiment('_Fixtures', function() {
+  var runtime = {};
+  lab.before(function(done) {
+    return seed(fixtures.categories)
+    .then(function(categories) {
+      runtime.categories = categories;
+      return seed(fixtures.users);
+    })
+    .then(function(boards) {
+      runtime.boards = boards;
+      return seed(fixtures.threads);
+    })
+    .then(function(threads) {
+      runtime.threads = threads;
+      return seed(fixtures.posts);
+    });
+  });
+  lab.test('should have corresponding amount of runtime data', function(done) {
+    Object.keys(fixtures).forEach(function(datatype) {
+      Object.keys(fixtures[datatype].data).forEach(function(subDatatype) {
+        expect(fixtures[datatype].data[subDatatype].length).to.equal(runtime[datatype][subDatatype].length);
+      });
+    });
+    done();
+  });
+});

--- a/test/threads.js
+++ b/test/threads.js
@@ -1,0 +1,140 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, 'db'));
+var seed = require(path.join(__dirname, 'seed', 'populate'));
+var fixture = require(path.join(__dirname, 'fixtures', 'threads'));
+var clean = require(path.join(__dirname, 'seed', 'clean'));
+var NotFoundError = Promise.OperationalError;
+
+lab.experiment('Threads', function() {
+  var runtime;
+  var expectations = function(seededThread, thread) {
+    expect(thread).to.exist;
+    expect(thread.board_id).to.equal(seededThread.board_id);
+  };
+  lab.before({timeout: 5000}, function(done) {
+    seed(fixture)
+    .then(function(results) {
+      runtime = results;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should find a thread by id', function(done) {
+    Promise.map(runtime.threads, function(seededThread) {
+      return db.threads.find(seededThread.id)
+      .then(function(thread) {
+        expectations(seededThread, thread);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should fail to find a thread by invalid id', function(done) {
+    db.threads.find()
+    .then(function(thread) {
+      throw new Error('Should not have found a thread');
+    })
+    .catch(function(err) {
+      expect(err).to.be.an.instanceof(NotFoundError);
+      expect(err.cause).to.be.a.string().and.to.equal('Thread Not Found');
+      done();
+    });
+  });
+  lab.test('should return threads for a board', function(done) {
+    Promise.map(runtime.boards.slice(0, 3), function(parentBoard) {
+      return db.threads.byBoard(parentBoard.id)
+      .then(function(threads) {
+        expect(threads).to.exist;
+        expect(threads.normal.length).to.equal(3);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should not return threads for a board', function(done) {
+    Promise.map(runtime.boards.slice(3, 5), function(parentBoard) {
+      return db.threads.byBoard(parentBoard.id)
+      .then(function(threads) {
+        expect(threads).to.exist;
+        expect(threads.normal).to.have.length(0);
+        expect(threads.sticky).to.have.length(0);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should return no threads for an invalid board', function(done) {
+    db.threads.byBoard()
+    .then(function(threads) {
+      expect(threads).to.exist;
+      expect(threads.normal).to.have.length(0);
+      expect(threads.sticky).to.have.length(0);
+    })
+    .catch(function(err) {
+      throw err;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should increment board\'s thread count', function(done) {
+    Promise.map(runtime.boards.slice(0, 3), function(seededBoard) {
+      return db.boards.find(seededBoard.id)
+      .then(function(board) {
+        expect(board.thread_count).to.equal(3);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should increment its view count', function(done) {
+    Promise.map(runtime.threads, function(seededThread) {
+      return db.threads.incViewCount(seededThread.id)
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      return Promise.map(runtime.boards.slice(0, 3), function(parentBoard) {
+        return db.threads.byBoard(parentBoard.id)
+        .then(function(threads) {
+          threads.normal.map(function(thread) {
+            expect(thread.view_count).to.equal(1);
+          });
+        })
+        .catch(function(err) {
+          throw err;
+        });
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.after(function(done) {
+    clean().then(function() {
+      done();
+    });
+  });
+});

--- a/test/users.js
+++ b/test/users.js
@@ -6,6 +6,7 @@ var Promise = require('bluebird');
 var db = require(path.join(__dirname, 'db'));
 var seed = require(path.join(__dirname, 'seed', 'populate'));
 var fixture = require(path.join(__dirname, 'fixtures', 'users'));
+var clean = require(path.join(__dirname, 'seed', 'clean'));
 var NotFoundError = Promise.OperationalError;
 
 lab.experiment('Users', function() {
@@ -103,6 +104,11 @@ lab.experiment('Users', function() {
     .catch(function(err) {
       expect(err).to.be.an.instanceof(NotFoundError);
       expect(err.cause).to.be.a.string().and.to.equal('User Not Found');
+      done();
+    });
+  });
+  lab.after(function(done) {
+    clean().then(function() {
       done();
     });
   });

--- a/test/users.js
+++ b/test/users.js
@@ -18,7 +18,7 @@ lab.experiment('Users', function() {
     expect(user.id).to.equal(seededUser.id);
   };
   lab.before({timeout: 5000}, function(done) {
-    return seed(fixture).then(function(results) {
+    seed(fixture).then(function(results) {
       runtime = results;
     })
     .then(function() {
@@ -26,7 +26,7 @@ lab.experiment('Users', function() {
     });
   });
   lab.test('should fail to create a user with invalid parameters', function(done) {
-    return db.users.create({})
+    db.users.create({})
     .then(function(user) {
       expect(user).to.not.exist();
       throw new Error('User creation should have failed');
@@ -49,7 +49,7 @@ lab.experiment('Users', function() {
     });
   });
   lab.test('should not return a user by invalid username', function(done) {
-    return db.users.userByUsername().then(function(user) {
+    db.users.userByUsername().then(function(user) {
       expect(user).to.not.exist();
     })
     .then(function() {
@@ -73,7 +73,7 @@ lab.experiment('Users', function() {
     });
   });
   lab.test('should not return a user by invalid email', function(done) {
-    return db.users.userByEmail().then(function(user) {
+    db.users.userByEmail().then(function(user) {
       expect(user).to.be.undefined();
     })
     .then(function() {
@@ -97,7 +97,7 @@ lab.experiment('Users', function() {
     });
   });
   lab.test('should fail to find a user by invalid id', function(done) {
-    return db.users.find()
+    db.users.find()
     .then(function(user) {
       throw new Error('Should not have found a user');
     })

--- a/test/users.js
+++ b/test/users.js
@@ -1,0 +1,109 @@
+var path = require('path');
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var expect = require('code').expect;
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, 'db'));
+var seed = require(path.join(__dirname, 'seed', 'populate'));
+var fixture = require(path.join(__dirname, 'fixtures', 'users'));
+var NotFoundError = Promise.OperationalError;
+
+lab.experiment('Users', function() {
+  var runtime;
+  var expectations = function(seededUser, user) {
+    expect(user).to.exist;
+    expect(user.username).to.equal(seededUser.username);
+    expect(user.email).to.equal(seededUser.email);
+    expect(user.id).to.equal(seededUser.id);
+  };
+  lab.before({timeout: 5000}, function(done) {
+    return seed(fixture).then(function(results) {
+      runtime = results;
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should fail to create a user with invalid parameters', function(done) {
+    return db.users.create({})
+    .then(function(user) {
+      expect(user).to.not.exist();
+      throw new Error('User creation should have failed');
+    })
+    .catch(function(err) {
+      done();
+    });
+  });
+  lab.test('should return a user by username', function(done) {
+    Promise.map(runtime.users, function(seededUser) {
+      return db.users.userByUsername(seededUser.username).then(function(user) {
+        expectations(seededUser, user);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should not return a user by invalid username', function(done) {
+    return db.users.userByUsername().then(function(user) {
+      expect(user).to.not.exist();
+    })
+    .then(function() {
+      done();
+    })
+    .catch(function(err) {
+      throw err;
+    });
+  });
+  lab.test('should return a user by email', function(done) {
+    Promise.map(runtime.users, function(seededUser) {
+      return db.users.userByEmail(seededUser.email).then(function(user) {
+        expectations(seededUser, user);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should not return a user by invalid email', function(done) {
+    return db.users.userByEmail().then(function(user) {
+      expect(user).to.be.undefined();
+    })
+    .then(function() {
+      done();
+    })
+    .catch(function(err) {
+      throw err;
+    });
+  });
+  lab.test('should find a user by id', function(done) {
+    Promise.map(runtime.users, function(seededUser) {
+      return db.users.find(seededUser.id).then(function(user) {
+        expectations(seededUser, user);
+      })
+      .catch(function(err) {
+        throw err;
+      });
+    })
+    .then(function() {
+      done();
+    });
+  });
+  lab.test('should fail to find a user by invalid id', function(done) {
+    return db.users.find()
+    .then(function(user) {
+      throw new Error('Should not have found a user');
+    })
+    .catch(function(err) {
+      expect(err).to.be.an.instanceof(NotFoundError);
+      expect(err.cause).to.be.a.string().and.to.equal('User Not Found');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
reintegrates tests from core-pg into epochtalk.  with the module system, db methods are tested in the integrated project (many are from `/modules`).

this change adds tests that were previously being run for

* categories
* boards
* threads
* posts
* notifications
* users

further db tests may be written.  inclusion of API tests are enqueued

these changes also include configurations for Circle CI, and the build has been updated accordingly

* updated circle ci node version
* kicked off build again with no cache to get rid of bcrypt install errors
* added environment variables for running the test

as a suggestion:
taking a look at the db methods, it may be good to completely get rid of core-pg altogether, if functionality can be completely integrated into the epochtalk repo through modules.