### PR TITLE
Patch to remove newbie as default role when registering

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,6 +5,7 @@ var config = {
   privateKey: process.env.PRIVATE_KEY,
   inviteOnly: process.env.INVITE_ONLY === 'true' || false,
   saasMode: process.env.SAAS_MODE === 'true' || false,
+  newbieEnabled: process.env.NEWBIE_ENABLED === 'true' || false,
   recaptchaSiteKey: process.env.RECAPTCHA_SITE_KEY,
   recaptchaSecretKey: process.env.RECAPTCHA_SECRET_KEY,
   gaKey: process.env.GA_KEY || 'UA-XXXXX-Y',

--- a/configurations.json
+++ b/configurations.json
@@ -4,6 +4,7 @@
   "loginRequired": false,
   "inviteOnly": false,
   "saasMode": false,
+  "newbieEnabled": false,
   "gaKey": "UA-XXXXX-Y",
   "website": {
     "title": "Epochtalk Forums",

--- a/modules/ept-auth/routes/invite-register.js
+++ b/modules/ept-auth/routes/invite-register.js
@@ -68,7 +68,10 @@ module.exports = {
     .then(request.db.users.create)
     // set newbie role
     .tap(function(user) {
-      return request.db.roles.addRoles([user.username], 'CN0h5ZeBTGqMbzwVdMWahQ');
+      var newbieEnabled = request.server.app.config.newbieEnabled;
+      if (newbieEnabled) {
+        return request.db.roles.addRoles([user.username], 'CN0h5ZeBTGqMbzwVdMWahQ');
+      }
     })
     .then(request.session.save)
     .error(request.errorMap.toHttpError);

--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -82,7 +82,10 @@ module.exports = {
     var promise = request.db.users.create(newUser)
     // set newbie role
     .tap(function(user) {
-      return request.db.roles.addRoles([user.username], 'CN0h5ZeBTGqMbzwVdMWahQ');
+      var newbieEnabled = request.server.app.config.newbieEnabled;
+      if (newbieEnabled) {
+        return request.db.roles.addRoles([user.username], 'CN0h5ZeBTGqMbzwVdMWahQ');
+      }
     })
     // send confirmation email
     .then(function(user) {


### PR DESCRIPTION
* newbieEnabled is a new config setting which defaults the
  "newbie" role when registering if set to true. If false the newly
  registered forum members have the "user" role by default

* TODO: create a migration which adds the "newbieEnabled" configuration
  to the configurations db table