### PR TITLE
Fix for youtube embed breaking when using url bbcode

### DIFF
--- a/modules/ept-frontend/client/components/post_processing/post-processing.directive.js
+++ b/modules/ept-frontend/client/components/post_processing/post-processing.directive.js
@@ -41,7 +41,7 @@ module.exports = ['$timeout', '$filter', '$compile', function($timeout, $filter,
       };
 
       // Auto video embed Regex
-      var autoVideoRegex = /((http(s)?:\/\/)?)(www\.)?((youtube\.com\/)|(youtu.be\/))([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?/gi;
+      var autoVideoRegex = /((http(s)?:\/\/)?)(www\.)?((youtube\.com\/)|(youtu.be\/))([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?(?![^<]*?(?:<\/a>|\/?>))/gi;
       var autoVideo = function(url) {
         var temp = new URL(url);
 


### PR DESCRIPTION
*TEST PROCEEDURE*
1) make a post with the text `[url=https://www.youtube.com/watch?v=dQw4w9WgXcQ]Link Here[/url]`

2) Ensure that the post just creates a link to the video

3) Make another post with the text `https://www.youtube.com/watch?v=dQw4w9WgXcQ`

4) Ensure that the post embeds the video


*Changes*

* Added check to regex to make sure that the youtube link
  doesn't end in '>' or '</a>' using regex lookahead. This
  allows you to use the url bbcode to link a youtube vid
  normally and still automatically embed youtube links.

* Fixes #306