### PR TITLE
invitations paging: move limit + 1 to db method

### DIFF
--- a/modules/ept-users/db/invitations.js
+++ b/modules/ept-users/db/invitations.js
@@ -16,5 +16,6 @@ module.exports = function(opts) {
     FROM invitations
     ORDER BY created_at DESC
     LIMIT $1 OFFSET $2`;
-  return db.sqlQuery(q, [opts.limit, opts.offset]);
+  // adjust limit to check if there's another page
+  return db.sqlQuery(q, [opts.limit + 1, opts.offset]);
 };

--- a/modules/ept-users/routes/invitations.js
+++ b/modules/ept-users/routes/invitations.js
@@ -34,10 +34,9 @@ module.exports = {
     pre: [ { method: 'auth.users.invitations(server, auth)' } ]
   },
   handler: function(request, reply) {
-    // adjust limit to check if there's another page
     var opts = {
       page: request.query.page,
-      limit: request.query.limit + 1
+      limit: request.query.limit
     };
 
     // query invitations


### PR DESCRIPTION
limit is ALSO used in the offset.  changing it in the route call causes
the offset to be calculated incorrectly