### PR TITLE
Fix for image store when using local hosting and rel paths

### DIFF
--- a/server/plugins/imageStore/s3.js
+++ b/server/plugins/imageStore/s3.js
@@ -126,6 +126,9 @@ var uploadImage = function(url, filename) {
       });
       sc.on('error', function(err) { return console.log(err); });
 
+      // Handle relative paths
+      if (url[0] === '/') { url = config.publicUrl + url; }
+
       // get image from url and pipe to cdn
       var stream = request(url)
       .on('error', function(err) { console.log(err); })


### PR DESCRIPTION
Relative paths when hosting local images would break the request module