### PR TITLE
Fix for youtube link parsing

### DIFF
--- a/modules/ept-frontend/client/components/post_processing/post-processing.directive.js
+++ b/modules/ept-frontend/client/components/post_processing/post-processing.directive.js
@@ -42,7 +42,7 @@ module.exports = ['$timeout', '$filter', '$compile', function($timeout, $filter,
       };
 
       // Auto video embed Regex
-      var autoVideoRegex = /((http(s)?:\/\/)?)(www\.)?((youtube\.com\/)|(youtu.be\/))([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?(?![^<]*?(?:<\/a>|\/?>))/gi;
+      var autoVideoRegex = /(?:.+?)?(?:\/v\/|watch\/|\?v=|\&v=|youtu\.be\/|\/v=|^youtu\.be\/|\/youtu.be\/)([a-zA-Z0-9_-]{11})+(?:[a-zA-Z0-9;:@#?&%=+\/\$_.-]*)*(?:(t=(?:(\d+h)?(\d+m)?(\d+s)?)))*/gi;
       var autoVideo = function(url) {
         var temp = new URL(url);
 
@@ -62,6 +62,9 @@ module.exports = ['$timeout', '$filter', '$compile', function($timeout, $filter,
 
         // time search param
         var time = queryParams.t;
+        if (time.indexOf('s') === time.length - 1) {
+          time = time.slice(0, -1);
+        }
         var src = 'https://www.youtube.com/embed/' + key;
         if (time) { src += '?start=' + time; }
 


### PR DESCRIPTION
* Prior to this commit 'youtube.com/' would be parsed into ''

* Properly handling linking youtube videos at a specific time

Resolves #351 