### PR TITLE
Changed how hidden categories work in board management

### DIFF
--- a/modules/ept-frontend/client/components/category_editor/category-editor.directive.js
+++ b/modules/ept-frontend/client/components/category_editor/category-editor.directive.js
@@ -62,6 +62,24 @@ var directive = ['$state', function($state) {
         editCat.name = $('#editCatName').val();
         editCat.viewable_by = $('#editCatViewable').val();
 
+        var nestedBoardDataId;
+
+        // Automatically apply same viewable by settings to nested boards
+        editCatEl
+        .children()
+        .find('[data-id]')
+        .each(function() {
+          nestedBoardDataId = $(this).data('id');
+          var editBoard = $scope.nestableMap[nestedBoardDataId];
+          editBoardDataId = nestedBoardDataId;
+          editBoardId = editBoard.id;
+          $('#editBoardName').val(editBoard.name);
+          $('#editBoardDesc').val(editBoard.description);
+          $('#editBoardViewable').val($('#editCatViewable').val());
+          $('#editBoardPostable').val(editBoard.postable_by);
+          $scope.editBoard();
+        });
+
         // Reset and close
         editCatDataId = '';
         $('#editCatName').val('');


### PR DESCRIPTION
* Resolves #213

* When changing the viewable by option of a category, now all nested
  boards automatically have the same viewable by option applied.
  This makes it so when you hide a category, all nested boards are
  hidden as well.

* This is temporary fix for the issue with posts under hidden categories
  showing in the posts by user views. This should be full resolved by
  making changes to how the board mapping works, but as a temporary
  solution, this change should suffice.