### PR TITLE
Seed now doesn't need to start up the server to run

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -7,6 +7,7 @@ var users = require(path.normalize(__dirname + '/../modules/ept-users')).db;
 var categories = require(path.normalize(__dirname + '/../modules/ept-categories')).db;
 var boards = require(path.normalize(__dirname + '/../modules/ept-boards')).db;
 var config = require(path.join(__dirname, '..', 'config'));
+var roles = require(path.join(__dirname, '..', 'server', 'plugins', 'acls'));
 
 var emailerOptions = config.emailer;
 var emailer = require(path.normalize(__dirname + '/../server/plugins/emailer')).expose(emailerOptions);
@@ -38,10 +39,14 @@ program
   .command('seed')
   .description('Seed database. Populates with initial user/board.')
   .action(function() {
-    seed()
+    roles.verifyRoles()
+    .then(function() {
+      return seed();
+    })
     .then(function() {
       process.exit(0);
-    });
+    })
+    .catch(console.log);
   });
 
 // the create-user command

--- a/server/plugins/acls/index.js
+++ b/server/plugins/acls/index.js
@@ -123,6 +123,12 @@ function getPriorityRestrictions(auth) {
 }
 
 function verifyRoles() {
+  if (!db) {
+    db = require(path.normalize(__dirname + '/../../../db'));
+    var modules = require(path.normalize(__dirname + '/../modules'));
+    var master = modules.install(db);
+    buildRoles(master.permissions.defaults);
+  }
   // get all the roles from the DB
   return db.roles.all()
   // find any that are missing and add them
@@ -271,6 +277,7 @@ function reprioritizeRoles(allRoles) {
   allRoles.forEach(function(role) { roles[role.lookup].priority = role.priority; });
 }
 
+exports.verifyRoles = verifyRoles;
 
 exports.register.attributes = {
   name: 'acls',

--- a/server/plugins/modules/index.js
+++ b/server/plugins/modules/index.js
@@ -108,6 +108,7 @@ modules.load = (dir, master) => {
   }
 };
 
+exports.install = modules.install;
 
 exports.register = (server, options, next) => {
   server = server || {};


### PR DESCRIPTION
* Updated the verifyRoles method to allow it to be called
  without the server running. This method populates the
  defualt roles and permissions if they aren't already
  present in the system.

* Fixes #358