### PR TITLE
read from config.emailerEnv in cli/index

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -9,7 +9,7 @@ var boards = require(path.normalize(__dirname + '/../modules/ept-boards')).db;
 var config = require(path.join(__dirname, '..', 'config'));
 var roles = require(path.join(__dirname, '..', 'server', 'plugins', 'acls'));
 
-var emailerOptions = config.emailer;
+var emailerOptions = config.emailerEnv;
 var emailer = require(path.normalize(__dirname + '/../server/plugins/emailer')).expose(emailerOptions);
 var dbName = process.env.PGDATABASE;
 var testConnection = require('epochtalk-core-pg')().db.testConnection;

--- a/example.env
+++ b/example.env
@@ -45,6 +45,7 @@ WEBSOCKET_SERVER_REDIS_DB=10
 # Variables with values configured at runtime
 ## Overrides for configurations values, configured by default on first run
 ## and configurable through the admin panel
+## See below for example configurations
 EMAILER_SENDER=info@example.com
 EMAILER_TRANSPORTER=ses
 EMAILER_OPTIONS_IGNORE_TLS=false
@@ -56,6 +57,33 @@ EMAILER_OPTIONS_SECURE=true
 EMAILER_OPTIONS_REGION=us-east
 EMAILER_OPTIONS_ACCESS_KEY_ID=SESACCESSKEY123
 EMAILER_OPTIONS_SECRET_ACCESS_KEY=SESSECRETKEY123
+
+### Example email configurations
+
+## Log emails to console
+# (No configuration)
+
+## SMTP
+# EMAILER_SENDER=info@example.com
+# EMAILER_OPTIONS_HOST=emailer.host
+# EMAILER_OPTIONS_PORT=465
+# EMAILER_OPTIONS_AUTH_USER=username
+# EMAILER_OPTIONS_AUTH_PASS=password
+# EMAILER_OPTIONS_SECURE=true
+
+## Amazon SES
+# EMAILER_TRANSPORTER=ses
+# EMAILER_SENDER=sender@addre.ss
+# EMAILER_OPTIONS_REGION=us-west-2
+# EMAILER_OPTIONS_ACCESS_KEY_ID=accesskey
+# EMAILER_OPTIONS_SECRET_ACCESS_KEY=secretaccesskey
+
+## Maildev (test emailer)
+# EMAILER_SENDER=info@example.com
+# EMAILER_OPTIONS_HOST=localhost
+# EMAILER_OPTIONS_PORT=1025
+# EMAILER_OPTIONS_IGNORE_TLS=true
+# EMAILER_OPTIONS_SECURE=false
 
 IMAGES_STORAGE=local
 IMAGES_MAX_SIZE=10485760


### PR DESCRIPTION
resolves #442

config.emailer does not contain any values when `setup.js` is run
therefore, the cli tool will not be able to properly instantiate the
emailer, even when options are correctly provided