### PR TITLE
include websocket service in app.js

### DIFF
--- a/modules/ept-frontend/client/app.js
+++ b/modules/ept-frontend/client/app.js
@@ -75,7 +75,7 @@ require('./patrol/resource');
 // Set Angular Configs
 app
 .config(require('./config'))
-.run(['$rootScope', '$state', '$timeout', 'Alert', 'BreadcrumbSvc', 'BanSvc', function($rootScope, $state, $timeout, Alert, BreadcrumbSvc, BanSvc) {
+.run(['$rootScope', '$state', '$timeout', 'Alert', 'BreadcrumbSvc', 'BanSvc', 'Websocket', function($rootScope, $state, $timeout, Alert, BreadcrumbSvc, BanSvc, Websocket) {
 
   // Fetch website configs (title, logo, favicon)
   $rootScope.$webConfigs = forumData;


### PR DESCRIPTION
ensures that websocket service is initialized on app load.
this way, users will can connect to websocket immediately on login after
loading the page

resolves #455 