### PR TITLE
implement disable websocket server

### DIFF
--- a/config.js
+++ b/config.js
@@ -28,6 +28,7 @@ var config = {
   recaptchaSiteKey: process.env.RECAPTCHA_SITE_KEY,
   recaptchaSecretKey: process.env.RECAPTCHA_SECRET_KEY,
   gaKey: process.env.GA_KEY || 'UA-XXXXX-Y',
+  disable_websocket_server: process.env.DISABLE_WEBSOCKET_SERVER === 'true' || false,
   websocket_host: process.env.WEBSOCKET_HOST,
   websocket_client_host: process.env.WEBSOCKET_CLIENT_HOST,
   websocket_port: process.env.WEBSOCKET_PORT,

--- a/example.env
+++ b/example.env
@@ -24,6 +24,7 @@ RECAPTCHA_SECRET_KEY=
 
 ## Set these if using websocket
 ## websocket client variables
+DISABLE_WEBSOCKET_SERVER=false
 WEBSOCKET_HOST=localhost
 WEBSOCKET_CLIENT_HOST=localhost
 WEBSOCKET_PORT=23958

--- a/server/index.js
+++ b/server/index.js
@@ -161,7 +161,12 @@ setup()
 .then(function() { return server.register({ register: lastActive }); })
 // Start websocket server
 .then(function() {
-  return websocketServer.start();
+  if (config.disable_websocket_server) {
+    return;
+  }
+  else {
+    return websocketServer.start();
+  }
 })
 // routes and server start
 .then(function() {


### PR DESCRIPTION
resolves #475 

websocket server can now be disabled by setting the env variable:

`DISABLE_WEBSOCKET_SERVER=true`

setting this variable to anything else or not setting it at all will
leave the websocket server enabled