### PR TITLE
Add back console log which shows errors in the inspector

### DIFF
--- a/modules/ept-frontend/client/app.js
+++ b/modules/ept-frontend/client/app.js
@@ -100,6 +100,7 @@ app
     var next = transition.to();
     var nextParams = transition.params();
 
+    console.log(error);
     // stop page change
     if (error === 'NoPageChange') { return; }
 


### PR DESCRIPTION
This shows errors in the client browsers console. I accidentally removed this when fixing the transitions.