### PR TITLE
temporarily depend on epochtalk-api-tests:fixes-2019

### DIFF
--- a/circleci-docker-compose.yml
+++ b/circleci-docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   epochtalk-api-tests:
-    image: quay.io/epochtalk/epochtalk-api-tests:latest
+    image: quay.io/epochtalk/epochtalk-api-tests:fixes-2019
     ports:
       - "1025:1025"
     depends_on:


### PR DESCRIPTION
revert this after merging fixes-2019 into master on epochtalk-api-tests