### PR TITLE
Createcipheriv

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,6 +1,6 @@
 # Variables only configured in .env
 ## Host configurations
-PRIVATE_KEY=Change this to something more secure
+PRIVATE_KEY=ThisKeyMustBeThirtyTwoCharacters
 HOST=localhost
 PORT=8080
 PUBLIC_URL=http://localhost:8080/

--- a/example.env
+++ b/example.env
@@ -2,7 +2,7 @@
 ## Host configurations
 # private key must be 32 characters
 # to support createCipheriv
-PRIVATE_KEY=ThisKeyMustBeThirtyTwoCharacters
+PRIVATE_KEY=Change this to something more secure
 HOST=localhost
 PORT=8080
 PUBLIC_URL=http://localhost:8080/

--- a/example.env
+++ b/example.env
@@ -1,5 +1,7 @@
 # Variables only configured in .env
 ## Host configurations
+# private key must be 32 characters
+# to support createCipheriv
 PRIVATE_KEY=ThisKeyMustBeThirtyTwoCharacters
 HOST=localhost
 PORT=8080

--- a/modules/ept-images/plugins/local.js
+++ b/modules/ept-images/plugins/local.js
@@ -34,7 +34,8 @@ local.uploadPolicy = function(filename) {
 
   // hash policy
   let iv = crypto.randomBytes(ivLength);
-  let cipher = crypto.createCipheriv('aes-256-ctr', config.privateKey, iv);
+  let keyHash = crypto.createHash('md5').update(config.privateKey, 'utf-8').digest('hex').toUpperCase();
+  let cipher = crypto.createCipheriv('aes-256-ctr', keyHash, iv);
   var policyHash = cipher.update(policy,'utf8','hex');
   policyHash += cipher.final('hex');
 

--- a/modules/ept-images/plugins/local.js
+++ b/modules/ept-images/plugins/local.js
@@ -12,6 +12,7 @@ var through2 = require('through2');
 var images = require(path.normalize(__dirname + '/images'));
 var Magic = mmm.Magic;
 var config;
+const ivLength = 16; // aes encryption
 
 local.init = function(opts) {
   opts = opts || {};
@@ -32,7 +33,8 @@ local.uploadPolicy = function(filename) {
   policy = JSON.stringify(policy);
 
   // hash policy
-  var cipher = crypto.createCipher('aes-256-ctr', config.privateKey);
+  let iv = crypto.randomBytes(ivLength);
+  let cipher = crypto.createCipheriv('aes-256-ctr', config.privateKey, iv);
   var policyHash = cipher.update(policy,'utf8','hex');
   policyHash += cipher.final('hex');
 
@@ -41,7 +43,7 @@ local.uploadPolicy = function(filename) {
 
   return {
     uploadUrl: '/api/images/upload',
-    policy: policyHash,
+    policy: iv.toString('hex') + ':' + policyHash.toString('hex'),
     storageType: 'local',
     imageUrl: imageUrl
   };

--- a/modules/ept-images/routes/localUpload.js
+++ b/modules/ept-images/routes/localUpload.js
@@ -29,7 +29,8 @@ module.exports = function(internalConfig) {
       let policyParts = request.payload.policy.split(':');
       let iv = Buffer.from(policyParts[0], 'hex');
       let policyPayload = policyParts[1];
-      let decipher = crypto.createDecipheriv('aes-256-ctr', config.privateKey, iv);
+      let keyHash = crypto.createHash('md5').update(config.privateKey, 'utf-8').digest('hex').toUpperCase();
+      let decipher = crypto.createDecipheriv('aes-256-ctr', keyHash, iv);
       var decoded = decipher.update(policyPayload,'hex','utf8');
       decoded += decipher.final('utf8');
 

--- a/modules/ept-images/routes/localUpload.js
+++ b/modules/ept-images/routes/localUpload.js
@@ -26,8 +26,10 @@ module.exports = function(internalConfig) {
       if (!file) { return Boom.badRequest('No File Attached'); }
 
       // decode policy
-      var policyPayload = request.payload.policy;
-      var decipher = crypto.createDecipher('aes-256-ctr', config.privateKey);
+      let policyParts = request.payload.policy.split(':');
+      let iv = Buffer.from(policyParts[0], 'hex');
+      let policyPayload = policyParts[1];
+      let decipher = crypto.createDecipheriv('aes-256-ctr', config.privateKey, iv);
       var decoded = decipher.update(policyPayload,'hex','utf8');
       decoded += decipher.final('utf8');
 


### PR DESCRIPTION
use crypto.createCipheriv()
this gets rid of warnings about using deprecated createCipher()

unfortunately, we now depend on the PRIVATE_KEY being 32 characters. maybe we should split it out to a new variable for cipher creation?...