### PR TITLE
remove threads.reverse()

### DIFF
--- a/modules/ept-threads/db/byBoard.js
+++ b/modules/ept-threads/db/byBoard.js
@@ -66,8 +66,6 @@ var getNormalThreads = function(boardId, userId, opts) {
     return db.sqlQuery(query, params);
   })
   .then(function(threads) {
-    // reverse ordering if backward search
-    if (!opts.reversed) { threads.reverse(); }
     // rearrange last post and user properties
     return Promise.map(threads, function(thread) {
       return common.formatThread(thread, userId);


### PR DESCRIPTION
the reversal is already done by the end of outer query;
`ORDER BY tlist.update_at DESC`


this issue wasn't being noticed because the thread length should have exceeded quadruple the threads per page (default 60 posts); and only pages between (but not including) the halfway mark and and the latest page were affected

with this update, thread paging is now correct