### PR TITLE
Fix spacing issue with markdown lists

### DIFF
--- a/modules/ept-md-parser/client/parseFactory.js
+++ b/modules/ept-md-parser/client/parseFactory.js
@@ -35,12 +35,22 @@ function parse(input) {
   // replace whitespacing
   input = input.replace(/(?:\n\$ept-newline\$)/g, '\n');
   input = input.replace(/(?:\$ept-newline\$)/g, '\n');
+  input = input.replace(/(?:\$ept-newline\$)/g, '\n');
+
+  // allow single new line in list items
+  var liRegex = /<li>([\s\S]*?)<\/li>/gi;
+  var liMatches = input.match(liRegex);
+  if (liMatches) {
+    liMatches.forEach(function(val) {
+      var updatedVal = val.replace(/\n\n/g, '<br/>');
+      input = input.replace(val, updatedVal);
+    });
+  }
 
   // replace &#38;lt and &#38;lt; with < and >
   // Put back lt and gt after they get butchered by the md parser
   input = input.replace(/(?:&#38;lt;)/gi, '&lt;');
   input = input.replace(/(?:&#38;gt;)/gi, '&gt;');
-
   return input;
 }
 


### PR DESCRIPTION
* Allow for single newline per list item.

* fixes #650

You should now be able to create a list item with content on the next line, if you put more that one newline then a new list will be started. 

Should behave like this:
- Test: Single Line
- Test:
Next Line Same List Item
- Test:

Two Newlines not in list