### PR TITLE
check data.hasErrors()

### DIFF
--- a/scripts/tasks/webpack.js
+++ b/scripts/tasks/webpack.js
@@ -51,8 +51,7 @@ const config = {
         loader: 'html-loader'
       }
     ]
-  },
-  stats: 'errors-only'
+  }
 };
 
 module.exports = function() {
@@ -81,7 +80,7 @@ module.exports = function() {
   const webpackCallback = function(err, data) {
     if (err) return Promise.reject(err);
     console.log('Webpack Complete.');
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development' && data.hasErrors()) {
       console.log(data.toString({colors: true}));
     }
     return Promise.resolve(data);


### PR DESCRIPTION
fixes #673

the stats: 'errors-only' option does not actually do what it's supposed
to do in the node package.  therefore, we must check for errors manually
before logging