### PR TITLE
fix(circleci): increase no_output_timeout to 20m

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -92,7 +92,9 @@ jobs:
     steps:
       - checkout
       - run: yarn install
-      - run: npx semantic-release
+      - run:
+          command: npx semantic-release
+          no_output_timeout: 20m
 workflows:
   version: 2
   release:


### PR DESCRIPTION
default is 10 minutes of "inactivity", but the current implementation of
the timeout actually checks total time elapsed instead