### PR TITLE
Fix user search

### DIFF
--- a/modules/ept-users/db/count.js
+++ b/modules/ept-users/db/count.js
@@ -21,7 +21,7 @@ module.exports = function(opts) {
     }
     if (opts && opts.searchStr) {
       q += ' WHERE u.username LIKE $1';
-      params = [opts.searchStr + '%'];
+      params = ['%' + opts.searchStr + '%'];
     }
   }
   return db.sqlQuery(q, params)

--- a/modules/ept-users/db/lookup.js
+++ b/modules/ept-users/db/lookup.js
@@ -4,14 +4,17 @@ var db = dbc.db;
 var helper = dbc.helper;
 
 module.exports = function(username, ignoredUsername, limit) {
+  var sort = 'CASE WHEN username LIKE \'' + username + '\' THEN 1 ' +
+    'WHEN username LIKE \'' + username + '%\' THEN 2 ' +
+    'WHEN username LIKE \'%' + username + '%\'THEN 3 ELSE 4 END';
   var q, promise;
   if (ignoredUsername) {
-    q = 'SELECT id, username FROM users WHERE username LIKE $1 AND username != $2 ORDER BY username LIMIT $3';
-    queryPromise = db.sqlQuery(q, [username + '%', ignoredUsername, limit || 25]);
+    q = 'SELECT id, username FROM users WHERE username LIKE $1 AND username != $2 ORDER BY ' + sort + ' LIMIT $3';
+    queryPromise = db.sqlQuery(q, ['%' + username + '%', ignoredUsername, limit || 25]);
   }
   else {
-    q = 'SELECT id, username FROM users WHERE username LIKE $1 ORDER BY username LIMIT $2';
-    queryPromise = db.sqlQuery(q, [username + '%', limit || 25]);
+    q = 'SELECT id, username FROM users WHERE username LIKE $1 ORDER BY ' + sort + ' LIMIT $2';
+    queryPromise = db.sqlQuery(q, ['%' + username + '%', limit || 25]);
   }
   return queryPromise
   .then(helper.slugify);

--- a/modules/ept-users/db/pagePublic.js
+++ b/modules/ept-users/db/pagePublic.js
@@ -13,7 +13,6 @@ module.exports = function(opts) {
   var page = opts.page || 1;
   var offset = (page * limit) - limit;
   var sortField = opts.sortField || 'username';
-
   var order = opts.desc ? 'DESC' : 'ASC';
   var params;
   if (opts && opts.searchStr) {

--- a/modules/ept-users/db/pagePublic.js
+++ b/modules/ept-users/db/pagePublic.js
@@ -13,11 +13,22 @@ module.exports = function(opts) {
   var page = opts.page || 1;
   var offset = (page * limit) - limit;
   var sortField = opts.sortField || 'username';
+
   var order = opts.desc ? 'DESC' : 'ASC';
   var params;
   if (opts && opts.searchStr) {
-    q = [q, 'WHERE u.deleted = false AND u.username LIKE $1 ORDER BY', sortField, order, 'LIMIT $2 OFFSET $3'].join(' ');
-    params = [opts.searchStr + '%', limit, offset];
+    var sort = sortField;
+    // weight search results to return results in correct order
+    if (sort == 'username') {
+      sort = `CASE
+        WHEN username LIKE '${opts.searchStr}' THEN 1
+        WHEN username LIKE '${opts.searchStr}%' THEN 2
+        WHEN username LIKE '%${opts.searchStr}%' THEN 3
+        ELSE 4
+      END`;
+    }
+    q = [q, 'WHERE u.deleted = false AND u.username LIKE $1 ORDER BY', sort, order, 'LIMIT $2 OFFSET $3'].join(' ');
+    params = ['%' + opts.searchStr + '%', limit, offset];
   }
   else {
     q = [q, 'WHERE u.deleted = false ORDER BY', sortField, order, 'LIMIT $1 OFFSET $2'].join(' ');
@@ -31,7 +42,7 @@ module.exports = function(opts) {
     q = 'SELECT count(*) FROM users u';
     if (opts && opts.searchStr) {
       q += ' WHERE u.deleted = false AND u.username LIKE $1';
-      params = [opts.searchStr + '%'];
+      params = ['%' + opts.searchStr + '%'];
       return db.scalar(q, params);
     }
     else { return db.scalar(q); }

--- a/modules/ept-users/db/searchUsernames.js
+++ b/modules/ept-users/db/searchUsernames.js
@@ -4,8 +4,11 @@ var db = dbc.db;
 
 /* returns array of usernames matching searchStr */
 module.exports = function(searchStr, limit) {
-  var q = 'SELECT username FROM users WHERE username LIKE $1 ORDER BY username LIMIT $2';
-  var params = [searchStr + '%', limit || 15];
+  var sort = 'CASE WHEN username LIKE \'' + searchStr + '\' THEN 1 ' +
+    'WHEN username LIKE \'' + searchStr + '%\' THEN 2 ' +
+    'WHEN username LIKE \'%' + searchStr + '%\'THEN 3 ELSE 4 END';
+  var q = 'SELECT username FROM users WHERE username LIKE $1 ORDER BY ' + sort + ' LIMIT $2';
+  var params = ['%' + searchStr + '%', limit || 15];
   return db.sqlQuery(q, params)
   .map(function(user) { return user.username; });
 };


### PR DESCRIPTION
Test Procedure: 

Example: 'hello' should match adding weight to the search results
* **hello** (exact match)
* **hello**world (beginning of word match)
* jello**hello**jello (middle of word match)
* goodbye**Hello** (end of word match)

With that in mind test the above applies when:
1) When searching users to add in the admin panel roles
2) When paging users in the admin panel management page
3) When searching usernames when writing a new message
4) When searching users using member search

Fixes #639