### PR TITLE
chore: update drone-ssh command_timeout

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,7 @@ steps:
       from_secret: ssh_username
     key:
       from_secret: ssh_key
+    command_timeout: 5m
     script:
       - cd certbot-docker && /bin/bash ./update.sh
   when:


### PR DESCRIPTION
default timeout is 1 minute, not enough time for the entire ssh command
to execute when downloading new versions of containers