### PR TITLE
fix: #966 Updating `alert` positioning so it no longer blocks dropdown

### DIFF
--- a/modules/ept-frontend/client/layout/header.html
+++ b/modules/ept-frontend/client/layout/header.html
@@ -171,6 +171,7 @@
   </div>
 
   <motd></motd>
+  <alert></alert>
 </div>
 
 <div id="ban-notice" ng-if="HeaderCtrl.isBanned" ng-bind-html="HeaderCtrl.isBanned">
@@ -179,5 +180,4 @@
 
 <invite show="HeaderCtrl.showInvite"></invite>
 
-<alert></alert>
 

--- a/modules/ept-frontend/client/scss/ept/components/_alert-service.scss
+++ b/modules/ept-frontend/client/scss/ept/components/_alert-service.scss
@@ -1,6 +1,4 @@
 .alertService {
-  position: fixed;
-  top: $header-height;
   width: 960px;
   margin: auto;
   left: 0;
@@ -10,6 +8,7 @@
   background-color: $header-dropdown-bg-color;
   max-height: 6.75rem;
   overflow: auto;
+
   .alert-box {
     display: block;
     padding: 0.5rem 1rem;

--- a/modules/ept-frontend/client/scss/ept/components/_alert-service.scss
+++ b/modules/ept-frontend/client/scss/ept/components/_alert-service.scss
@@ -1,13 +1,19 @@
 .alertService {
-  width: 960px;
+  width: 100%;
   margin: auto;
   left: 0;
   right: 0;
   z-index: 9000;
-  @include border-radius(0 0 3px 3px);
+  @include border-radius(0 0 4px 4px);
   background-color: $header-dropdown-bg-color;
   max-height: 6.75rem;
+  max-width: 1300px;
   overflow: auto;
+  position: fixed;
+
+  .is-hidden & {
+    pointer-events: initial;
+  }
 
   .alert-box {
     display: block;


### PR DESCRIPTION
The alert message no longer obscures the user's dropdown menu
Alert message now scrolls away (with the header) when the user scrolls down the page