### PR TITLE
fix: #1009 Removing height style for `img` to allow height attribute …

### DIFF
--- a/modules/ept-frontend/client/scss/ept/global/_overrides.scss
+++ b/modules/ept-frontend/client/scss/ept/global/_overrides.scss
@@ -54,9 +54,10 @@ a {
   }
 }
 a.ng-show, a.ng-hide, input.ng-hide, input.ng-show { @include transition(none !important); }
+
 img {
   max-width: 100%;
-  height: auto;
+  max-height: 100%;
   display: inline-block;
   vertical-align: middle;
   -ms-interpolation-mode: bicubic;


### PR DESCRIPTION
…(bbcode)

Replacing height style with max-height
Images with height attribute set in bbcode should now appear at the correct size