### PR TITLE
fix: #1011 Fixing `<pre>` element width in post body

### DIFF
--- a/modules/ept-frontend/client/scss/ept/global/_posts.scss
+++ b/modules/ept-frontend/client/scss/ept/global/_posts.scss
@@ -28,6 +28,11 @@
     width: 100%;
     height: 100%;
   }
+
+  pre {
+    overflow-x: scroll;
+    word-wrap: normal;
+  }
 }
 .quoteHeader {
   border-left: $border-quote;


### PR DESCRIPTION
`<pre>` elements were extending beyond their container
Now they are constrained to the container width, with horizontal scrolling