### PR TITLE
fix: images in private messages

### DIFF
--- a/modules/ept-images/plugins/images.js
+++ b/modules/ept-images/plugins/images.js
@@ -114,7 +114,12 @@ images.imageSub = (post) => {
     return images.saveImage(imgSrc)
     .then(function(savedUrl) {
       if (savedUrl) {
-        post.body = post.body.replace(imgSrc, savedUrl);
+        if (post.content) {
+          post.content.body = post.content.body.replace(imgSrc, savedUrl);
+        }
+        else {
+          post.body = post.body.replace(imgSrc, savedUrl);
+        }
       }
     });
   })


### PR DESCRIPTION
check for post.content before replacing body