### PR TITLE
fix(db):  use set type parser

### DIFF
--- a/core/db.js
+++ b/core/db.js
@@ -2,6 +2,10 @@ var db = {};
 module.exports = db;
 var pg = require('pg');
 pg.defaults.parseInputDatesAsUTC = true;
+var types = pg.types;
+types.setTypeParser(1114, function(stringValue) {
+    return new Date(stringValue + "+0000");
+});
 var path = require('path');
 var Promise = require('bluebird');
 var config = require(path.join(__dirname, 'config'));


### PR DESCRIPTION
issue: on db query, timestamps are converted to the local timezone.
they should be read and kept as utc

on query, this change sets timezone to +0000 when the data type is
timestamp without timezone