### PR TITLE
fix(polls): check for user priority when editor is a mod

### DIFF
--- a/modules/ept-polls/client/poll_viewer.directive.js
+++ b/modules/ept-polls/client/poll_viewer.directive.js
@@ -47,7 +47,7 @@ var directive = ['Session', 'BanSvc', 'Alert', 'Threads', '$timeout', function(S
         else {
           if (Session.hasPermission('threads.editPoll.bypass.owner.admin')) { edit = true; }
           else if (Session.hasPermission('threads.editPoll.bypass.owner.priority') && Session.getPriority() < $scope.userPriority) { edit = true; }
-          else if (Session.hasPermission('threads.editPoll.bypass.owner.mod')) {
+          else if (Session.hasPermission('threads.editPoll.bypass.owner.mod') && Session.getPriority() < $scope.userPriority) {
             if (Session.moderatesBoard($scope.thread.board_id)) { edit = true; }
           }
         }
@@ -64,7 +64,7 @@ var directive = ['Session', 'BanSvc', 'Alert', 'Threads', '$timeout', function(S
         else {
           if (Session.hasPermission('threads.lockPoll.bypass.owner.admin')) { lock = true; }
           else if (Session.hasPermission('threads.lockPoll.bypass.owner.priority') && Session.getPriority() < $scope.userPriority) { lock = true; }
-          else if (Session.hasPermission('threads.lockPoll.bypass.owner.mod')) {
+          else if (Session.hasPermission('threads.lockPoll.bypass.owner.mod') && Session.getPriority() < $scope.userPriority) {
             if (Session.moderatesBoard($scope.thread.board_id)) { lock = true; }
           }
         }


### PR DESCRIPTION
previously would allow a mod to click the edit/lock button on a poll
without user priority.  actions didnt work, but UI should match api
permissions