### PR TITLE
fix(images-expiry): remove publicUrl from expiry url

### DIFF
--- a/modules/ept-images/plugins/images.js
+++ b/modules/ept-images/plugins/images.js
@@ -76,7 +76,8 @@ images.setExpiration = function(duration, url) {
 };
 
 images.clearExpiration = function(url) {
-  return db.images.clearImageExpiration(url);
+  // url replace is a fix for vue project image expiry
+  return db.images.clearImageExpiration(url.replace(config.publicUrl, ''));
 };
 
 var expire = function() {


### PR DESCRIPTION
vue project cannot serve image files served through this project
patch fix is to use full urls with local image hosting