### PR TITLE
Fix confirmation token

### DIFF
--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -38,7 +38,6 @@ var crypto = require('crypto');
   *
   * @apiSuccess {string} message Account creation success message
   * @apiSuccess {string} username Created user's username
-  * @apiSuccess {string} confirm_token Created user's account confirmation token
   * @apiSuccess {string} avatar User's avatar url
   *
   * @apiError (Error 400) BadRequest There was an error registering the user
@@ -103,8 +102,7 @@ module.exports = {
         request.emailer.send('confirmAccount', emailParams);
         return {
           message: 'Successfully Created Account',
-          username: user.username,
-          confirm_token: user.confirmation_token
+          username: user.username
         };
       }
       else { return user; }

--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -88,8 +88,8 @@ module.exports = {
     })
     // remove invitation if exists in db
     .tap(function(user) { return request.db.invitations.remove(user.email); })
-    // send confirmation email
     .then(function(user) {
+      // send confirmation email
       if (config.verifyRegistration) {
         var confirmUrl = config.publicUrl + '/' + path.join('confirm', user.username, user.confirmation_token);
         var emailParams = {
@@ -101,32 +101,29 @@ module.exports = {
         request.server.log('debug', emailParams);
         request.emailer.send('confirmAccount', emailParams);
         return {
+          avatar: '/static/img/avatar.png',
           message: 'Successfully Created Account',
           username: user.username
         };
       }
-      else { return user; }
-    })
-    // TODO: Move to post handler code
-    // check malicious score and ban if necessary
-    .then(function(createdUser) {
-      createdUser.avatar = '/static/img/avatar.png';
-      if (config.verifyRegistration) { return createdUser; }
+      // TODO: Move to post handler code
+      // check malicious score and ban if necessary
       else {
+        user.avatar = '/static/img/avatar.png';
         var ip = request.headers['x-forwarded-for'] || request.info.remoteAddress;
-        var opts = { ip: ip, userId: createdUser.id };
+        var opts = { ip: ip, userId: user.id };
         return request.db.bans.getMaliciousScore(opts)
         .then(function(score) {
           // User has a malicious score less than 1 let them register
-          if (score < 1) { return createdUser; }
+          if (score < 1) { return user; }
           // User has a malicious score equal to or higher than 1 ban the account
           else {
-            return request.db.bans.ban(createdUser.id)
+            return request.db.bans.ban(user.id)
             .then(function(banInfo) {
-              createdUser.malicious_score = score;
-              createdUser.roles = banInfo.roles;
-              createdUser.ban_expiration = banInfo.expiration;
-              return createdUser;
+              user.malicious_score = score;
+              user.roles = banInfo.roles;
+              user.ban_expiration = banInfo.expiration;
+              return user;
             });
           }
         })

--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -101,6 +101,7 @@ module.exports = {
         request.server.log('debug', emailParams);
         request.emailer.send('confirmAccount', emailParams);
         return {
+          confirm_token: true,
           avatar: '/static/img/avatar.png',
           message: 'Successfully Created Account',
           username: user.username

--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -102,7 +102,6 @@ module.exports = {
         request.emailer.send('confirmAccount', emailParams);
         return {
           confirm_token: true,
-          avatar: '/static/img/avatar.png',
           message: 'Successfully Created Account',
           username: user.username
         };

--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -119,7 +119,7 @@ module.exports = {
         .then(function(score) {
           // User has a malicious score less than 1 let them register
           if (score < 1) { return createdUser; }
-          // User has a malicious score higher than 1 ban the account
+          // User has a malicious score equal to or higher than 1 ban the account
           else {
             return request.db.bans.ban(createdUser.id)
             .then(function(banInfo) {

--- a/modules/ept-auth/routes/register.js
+++ b/modules/ept-auth/routes/register.js
@@ -36,9 +36,9 @@ var crypto = require('crypto');
   * @apiParam (Payload) {string} password User's password
   * @apiParam (Payload) {string} confirmation User's confirmed password
   *
+  * @apiSuccess {string} confirm_token true if account verification is enabled
   * @apiSuccess {string} message Account creation success message
   * @apiSuccess {string} username Created user's username
-  * @apiSuccess {string} avatar User's avatar url
   *
   * @apiError (Error 400) BadRequest There was an error registering the user
   */


### PR DESCRIPTION
while `verifyRegistration` is active,

for the `confirm_token` value,
instead of sending confirmation token to client on registration success,
send `true`

this prevents the user from being able to manually craft the registration url with the valid token
but also does not mess up the UI response by trying to log the user in

this change pending further review...

possible improvements are:

* changing the name of `confirm_token: true` to something like `confirmation_email_sent: true`

* not adding `avatar` to the returned user info if `verifyRegistration` is active, since they are not logged in